### PR TITLE
Telegram notifications, paper trading, scheduler updates

### DIFF
--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -46,10 +46,10 @@ jobs:
 
       - name: Run paper trade + send Telegram report
         env:
-          # PAPER_ESTIMATOR=free  → zero cost (default)
-          # PAPER_ESTIMATOR=claude → real Claude API
           PAPER_ESTIMATOR: free
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           cd polymarket_bot
           python run_paper_trade.py

--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -2,8 +2,8 @@ name: Polymarket Bot
 
 on:
   schedule:
-    # Paper trade daily report: 22:00 UTC+8 = 14:00 UTC
-    - cron: "0 14 * * *"
+    # Paper trade daily report: 22:20 UTC+8 = 14:20 UTC
+    - cron: "20 14 * * *"
     # Tier-1 price monitor: every 10 min, active hours (08-22 UTC)
     - cron: "*/10 8-22 * * *"
     # Off-peak monitor: every 60 min
@@ -23,7 +23,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'schedule' &&
-       startsWith(github.event.schedule, '0 14'))
+       startsWith(github.event.schedule, '20 14'))
 
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
     # Skip the 09:00 UTC slot (that's paper report time)
     if: >
       github.event_name == 'schedule' &&
-      !startsWith(github.event.schedule, '0 14')
+      !startsWith(github.event.schedule, '20 14')
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -2,8 +2,8 @@ name: Polymarket Bot
 
 on:
   schedule:
-    # Paper trade daily report: 22:20 UTC+8 = 14:20 UTC
-    - cron: "20 14 * * *"
+    # Paper trade daily report: 22:25 UTC+8 = 14:25 UTC
+    - cron: "25 14 * * *"
     # Tier-1 price monitor: every 10 min, active hours (08-22 UTC)
     - cron: "*/10 8-22 * * *"
     # Off-peak monitor: every 60 min
@@ -23,7 +23,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'schedule' &&
-       startsWith(github.event.schedule, '20 14'))
+       startsWith(github.event.schedule, '25 14'))
 
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
     # Skip the 09:00 UTC slot (that's paper report time)
     if: >
       github.event_name == 'schedule' &&
-      !startsWith(github.event.schedule, '20 14')
+      !startsWith(github.event.schedule, '25 14')
 
     steps:
       - uses: actions/checkout@v4

--- a/polymarket_bot/telegram_reporter.py
+++ b/polymarket_bot/telegram_reporter.py
@@ -1,19 +1,34 @@
 """
 Telegram report sender for paper trading daily summary.
 Uses Telegram Bot API sendMessage with MarkdownV2 formatting.
+
+Requires env vars:
+  TELEGRAM_BOT_TOKEN  — from @BotFather
+  TELEGRAM_CHAT_ID    — your personal chat ID
 """
 
 import logging
 import urllib.request
 import urllib.parse
 import json
+import os
 from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
-BOT_TOKEN = "8618325313:AAFo0681Yy5CV2XPygsZShrpjSd31L0BBTM"
-CHAT_ID = "8798947532"
-API_BASE = f"https://api.telegram.org/bot{BOT_TOKEN}"
+
+def _get_api_base() -> str:
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("TELEGRAM_BOT_TOKEN environment variable not set")
+    return f"https://api.telegram.org/bot{token}"
+
+
+def _get_chat_id() -> str:
+    chat_id = os.environ.get("TELEGRAM_CHAT_ID")
+    if not chat_id:
+        raise RuntimeError("TELEGRAM_CHAT_ID environment variable not set")
+    return chat_id
 
 
 def _esc(text: str) -> str:
@@ -38,9 +53,9 @@ def _fmt_pnl(val) -> str:
 
 def send_message(text: str) -> bool:
     """Send a MarkdownV2 message via Telegram Bot API."""
-    url = f"{API_BASE}/sendMessage"
+    url = f"{_get_api_base()}/sendMessage"
     payload = json.dumps({
-        "chat_id": CHAT_ID,
+        "chat_id": _get_chat_id(),
         "text": text,
         "parse_mode": "MarkdownV2",
         "disable_web_page_preview": True,


### PR DESCRIPTION
## 包含的更新

這些 commit 在上一個 PR merge 之後才推送，需要補進 master：

- **Telegram 通知**：取代 Email，每天 22:25（台灣時間）推送模擬交易日報到 Telegram
- **Credentials 安全化**：Bot Token / Chat ID 移至 GitHub Secrets，不再寫死在程式碼裡
- **模擬交易免費模式**：預設使用 free 估算器，不消耗 Claude API
- **時間調整**：報告時間設定為 22:25 UTC+8（14:25 UTC）

## 需要在 GitHub Secrets 設定

| Secret | 說明 |
|--------|------|
| `TELEGRAM_BOT_TOKEN` | Telegram Bot token |
| `TELEGRAM_CHAT_ID` | `8798947532` |
| `ANTHROPIC_API_KEY` | Claude API（之後真實交易用） |

https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein

---
_Generated by [Claude Code](https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein)_