### PR TITLE
Update daily report time to 22:50 UTC+8

### DIFF
--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -2,8 +2,8 @@ name: Polymarket Bot
 
 on:
   schedule:
-    # Paper trade daily report: 22:40 UTC+8 = 14:40 UTC
-    - cron: "40 14 * * *"
+    # Paper trade daily report: 22:50 UTC+8 = 14:50 UTC
+    - cron: "50 14 * * *"
     # Tier-1 price monitor: every 10 min, active hours (08-22 UTC)
     - cron: "*/10 8-22 * * *"
     # Off-peak monitor: every 60 min
@@ -23,7 +23,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'schedule' &&
-       startsWith(github.event.schedule, '40 14'))
+       startsWith(github.event.schedule, '50 14'))
 
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
     # Skip the 09:00 UTC slot (that's paper report time)
     if: >
       github.event_name == 'schedule' &&
-      !startsWith(github.event.schedule, '40 14')
+      !startsWith(github.event.schedule, '50 14')
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
每天晚上 **22:50（台灣時間）** 自動發送 Telegram 模擬交易日報。

包含所有未 merge 的更新：
- Telegram 通知（取代 Email）
- Token / Chat ID 從 GitHub Secrets 讀取
- 模擬交易免費模式
- 報告時間：22:50 UTC+8（14:50 UTC）

## 需要設定的 GitHub Secrets
| Secret | 值 |
|--------|---|
| `TELEGRAM_BOT_TOKEN` | 你的 bot token |
| `TELEGRAM_CHAT_ID` | `8798947532` |

https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein

---
_Generated by [Claude Code](https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein)_