### PR TITLE
Fix: wallet keys optional for paper trading

### DIFF
--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -2,8 +2,8 @@ name: Polymarket Bot
 
 on:
   schedule:
-    # Paper trade daily report: 22:50 UTC+8 = 14:50 UTC
-    - cron: "50 14 * * *"
+    # Paper trade daily report: 23:00 UTC+8 = 15:00 UTC
+    - cron: "0 15 * * *"
     # Tier-1 price monitor: every 10 min, active hours (08-22 UTC)
     - cron: "*/10 8-22 * * *"
     # Off-peak monitor: every 60 min
@@ -23,7 +23,7 @@ jobs:
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'schedule' &&
-       startsWith(github.event.schedule, '50 14'))
+       startsWith(github.event.schedule, '0 15'))
 
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
     # Skip the 09:00 UTC slot (that's paper report time)
     if: >
       github.event_name == 'schedule' &&
-      !startsWith(github.event.schedule, '50 14')
+      !startsWith(github.event.schedule, '0 15')
 
     steps:
       - uses: actions/checkout@v4

--- a/polymarket_bot/config.py
+++ b/polymarket_bot/config.py
@@ -3,9 +3,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-# Wallet / chain
-PRIVATE_KEY: str = os.environ["POLYMARKET_PRIVATE_KEY"]
-FUNDER_ADDRESS: str = os.environ["POLYMARKET_FUNDER_ADDRESS"]
+# Wallet / chain (only required for live trading, not paper trading)
+PRIVATE_KEY: str = os.environ.get("POLYMARKET_PRIVATE_KEY", "")
+FUNDER_ADDRESS: str = os.environ.get("POLYMARKET_FUNDER_ADDRESS", "")
 CHAIN_ID: int = 137  # Polygon mainnet
 SIGNATURE_TYPE: int = 0  # 0 = EOA/MetaMask; 1 = Magic/email proxy wallet
 


### PR DESCRIPTION
修正 `config.py`：`POLYMARKET_PRIVATE_KEY` 和 `POLYMARKET_FUNDER_ADDRESS` 改為 optional，模擬交易不需要錢包私鑰也能正常執行。

**錯誤原因：** `KeyError: 'POLYMARKET_PRIVATE_KEY'` — config 在 import 時就強制要求私鑰，導致模擬交易啟動失敗。

https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein

---
_Generated by [Claude Code](https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein)_