### PR TITLE
Fix workflow + add 30-min intraday niche scan with Telegram alerts

### DIFF
--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -4,8 +4,8 @@ on:
   schedule:
     # Daily paper trade report: 23:00 UTC+8 = 15:00 UTC
     - cron: "0 15 * * *"
-    # Intraday S5 niche scan: every 15 min 24/7
-    - cron: "*/15 * * * *"
+    # Intraday S5 niche scan: every ~23 min (0,23,46 of each hour)
+    - cron: "*/23 * * * *"
   workflow_dispatch:
     inputs:
       force_report:

--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -2,8 +2,10 @@ name: Polymarket Bot
 
 on:
   schedule:
-    # Paper trade daily report: 23:00 UTC+8 = 15:00 UTC
+    # Daily paper trade report: 23:00 UTC+8 = 15:00 UTC
     - cron: "0 15 * * *"
+    # Intraday S5 niche scan: every 15 min 24/7
+    - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
       force_report:
@@ -18,7 +20,6 @@ jobs:
     name: "Paper Trade + Daily Report"
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Only run on the 15:00 UTC daily cron, OR manual dispatch with force_report=yes
     if: >
       (github.event_name == 'workflow_dispatch' && github.event.inputs.force_report == 'yes') ||
       (github.event_name == 'schedule' &&
@@ -43,9 +44,10 @@ jobs:
           restore-keys: |
             paper-state-
 
-      - name: Run paper trade + send Telegram report
+      - name: Run paper trade + send Telegram daily report
         env:
           PAPER_ESTIMATOR: free
+          SEND_DAILY_REPORT: "true"
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
@@ -60,38 +62,63 @@ jobs:
           path: polymarket_bot/paper_trades.json
           key: paper-state-${{ github.run_id }}
 
-  # ── Job 2: Live scan — only added back when POLYMARKET_PRIVATE_KEY is ready ──
-  # Uncomment the schedule block below and set POLYMARKET_PRIVATE_KEY in Secrets
-  # to enable live trading.
+  # ── Job 2: Intraday S5 niche scan every 15 min ───────────────────────────────
+  paper_scan:
+    name: "Intraday Paper Scan"
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    # Skip the 15:00 UTC slot — daily report job handles that run
+    if: >
+      github.event_name == 'schedule' &&
+      !startsWith(github.event.schedule, '0 15')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r polymarket_bot/requirements.txt -q
+
+      - name: Restore paper trade state
+        uses: actions/cache@v4
+        with:
+          path: polymarket_bot/paper_trades.json
+          key: paper-state-${{ github.run_id }}
+          restore-keys: |
+            paper-state-
+
+      - name: Scan niche markets + alert on new signals
+        env:
+          PAPER_ESTIMATOR: free
+          SEND_DAILY_REPORT: "false"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          cd polymarket_bot
+          python run_paper_trade.py
+
+      - name: Save paper trade state
+        if: always()
+        uses: actions/cache@v4
+        with:
+          path: polymarket_bot/paper_trades.json
+          key: paper-state-${{ github.run_id }}
+
+  # ── Job 3: Live scan — uncomment when POLYMARKET_PRIVATE_KEY is ready ────────
+  # Add these crons to the schedule trigger above:
+  #   - cron: "*/10 8-22 * * *"   # every 10 min active hours
+  #   - cron: "0 22-23,0-7 * * *" # every hour off-peak
   #
   # live_scan:
   #   name: "Live Market Scan"
   #   runs-on: ubuntu-latest
   #   timeout-minutes: 8
-  #   if: github.event_name == 'schedule'
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v5
-  #       with:
-  #         python-version: "3.11"
-  #         cache: pip
-  #     - run: pip install -r polymarket_bot/requirements.txt -q
-  #     - uses: actions/cache@v4
-  #       with:
-  #         path: polymarket_bot/price_cache.json
-  #         key: price-cache-${{ github.run_id }}
-  #         restore-keys: price-cache-
-  #     - name: Run Tier-1 price monitor
-  #       env:
-  #         POLYMARKET_PRIVATE_KEY: ${{ secrets.POLYMARKET_PRIVATE_KEY }}
-  #         POLYMARKET_FUNDER_ADDRESS: ${{ secrets.POLYMARKET_FUNDER_ADDRESS }}
-  #         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-  #         TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-  #         TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-  #       run: |
-  #         cd polymarket_bot && python -c "..."
-  #     - uses: actions/cache@v4
-  #       if: always()
-  #       with:
-  #         path: polymarket_bot/price_cache.json
-  #         key: price-cache-${{ github.run_id }}
+  #   if: >
+  #     github.event_name == 'schedule' &&
+  #     !startsWith(github.event.schedule, '0 15')
+  #   steps: ...

--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -4,12 +4,6 @@ on:
   schedule:
     # Paper trade daily report: 23:00 UTC+8 = 15:00 UTC
     - cron: "0 15 * * *"
-    # Tier-1 price monitor: every 10 min, active hours (08-22 UTC)
-    - cron: "*/10 8-22 * * *"
-    # Off-peak monitor: every 60 min
-    - cron: "0 22-23,0-7 * * *"
-    # Crypto: every 15 min 24/7
-    - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
       force_report:
@@ -66,115 +60,38 @@ jobs:
           path: polymarket_bot/paper_trades.json
           key: paper-state-${{ github.run_id }}
 
-  # ── Job 2: Live scan (real trading, skips when no private key configured) ────
-  live_scan:
-    name: "Live Market Scan"
-    runs-on: ubuntu-latest
-    timeout-minutes: 8
-    # Skip the 15:00 UTC slot (that's daily report time); never run on manual dispatch
-    if: >
-      github.event_name == 'schedule' &&
-      !startsWith(github.event.schedule, '0 15')
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-
-      - name: Install dependencies
-        run: pip install -r polymarket_bot/requirements.txt -q
-
-      - name: Restore price cache
-        uses: actions/cache@v4
-        with:
-          path: polymarket_bot/price_cache.json
-          key: price-cache-${{ github.run_id }}
-          restore-keys: |
-            price-cache-
-
-      - name: Run Tier-1 price monitor
-        env:
-          POLYMARKET_PRIVATE_KEY: ${{ secrets.POLYMARKET_PRIVATE_KEY }}
-          POLYMARKET_FUNDER_ADDRESS: ${{ secrets.POLYMARKET_FUNDER_ADDRESS }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-        run: |
-          cd polymarket_bot
-          python -c "
-          import logging, os
-          logging.basicConfig(level=logging.INFO, format='%(asctime)s | %(levelname)s | %(message)s')
-
-          if not os.environ.get('POLYMARKET_PRIVATE_KEY'):
-              print('No POLYMARKET_PRIVATE_KEY configured — paper trading mode, skipping live scan.')
-              exit(0)
-
-          from tier1_monitor import fetch_price_snapshot, detect_changed_markets
-          from scanner import filter_markets
-
-          snapshot = fetch_price_snapshot()
-          changed = detect_changed_markets(snapshot)
-
-          if not changed:
-              print('No price changes — skipping.')
-              exit(0)
-
-          print(f'{len(changed)} markets changed — evaluating...')
-
-          from executor import build_clob_client
-          from tracker import Tracker
-          from valuator import estimate_fair_probability
-          from strategy import evaluate_market
-          from executor import place_limit_order
-          from datetime import datetime, timezone
-
-          clob = build_clob_client()
-          tracker = Tracker(clob)
-
-          if not tracker.is_alive():
-              print('Kill switch triggered. Exiting.')
-              exit(0)
-
-          bankroll = tracker.get_usdc_balance()
-          now = datetime.now(timezone.utc).isoformat()
-          tradeable = filter_markets(changed)
-          signals = orders = 0
-
-          for market in tradeable:
-              bankroll = tracker.get_usdc_balance()
-              if bankroll <= 0:
-                  break
-              fair = estimate_fair_probability(market, tracker)
-              if fair is None:
-                  continue
-              signal = evaluate_market(market, fair, bankroll)
-              if signal is None:
-                  continue
-              signals += 1
-              if place_limit_order(clob, signal, tracker, now):
-                  orders += 1
-
-          summary = tracker.summary()
-          print(f'Done — signals={signals} orders={orders} | {summary}')
-
-          if orders > 0:
-              from telegram_reporter import send_message
-              ts = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')
-              msg = (
-                  f'*🔔 Polymarket 實盤成交通知*\n'
-                  f'_{ts}_\n\n'
-                  f'已下單 *{orders}* 筆\\|信號 {signals} 筆\n'
-                  f'{summary}'
-              )
-              send_message(msg)
-          "
-
-      - name: Save price cache
-        if: always()
-        uses: actions/cache@v4
-        with:
-          path: polymarket_bot/price_cache.json
-          key: price-cache-${{ github.run_id }}
+  # ── Job 2: Live scan — only added back when POLYMARKET_PRIVATE_KEY is ready ──
+  # Uncomment the schedule block below and set POLYMARKET_PRIVATE_KEY in Secrets
+  # to enable live trading.
+  #
+  # live_scan:
+  #   name: "Live Market Scan"
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 8
+  #   if: github.event_name == 'schedule'
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.11"
+  #         cache: pip
+  #     - run: pip install -r polymarket_bot/requirements.txt -q
+  #     - uses: actions/cache@v4
+  #       with:
+  #         path: polymarket_bot/price_cache.json
+  #         key: price-cache-${{ github.run_id }}
+  #         restore-keys: price-cache-
+  #     - name: Run Tier-1 price monitor
+  #       env:
+  #         POLYMARKET_PRIVATE_KEY: ${{ secrets.POLYMARKET_PRIVATE_KEY }}
+  #         POLYMARKET_FUNDER_ADDRESS: ${{ secrets.POLYMARKET_FUNDER_ADDRESS }}
+  #         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  #         TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+  #         TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+  #       run: |
+  #         cd polymarket_bot && python -c "..."
+  #     - uses: actions/cache@v4
+  #       if: always()
+  #       with:
+  #         path: polymarket_bot/price_cache.json
+  #         key: price-cache-${{ github.run_id }}

--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -4,8 +4,8 @@ on:
   schedule:
     # Daily paper trade report: 23:00 UTC+8 = 15:00 UTC
     - cron: "0 15 * * *"
-    # Intraday S5 niche scan: every ~23 min (0,23,46 of each hour)
-    - cron: "*/23 * * * *"
+    # Intraday S5 niche scan: every 30 min
+    - cron: "*/30 * * * *"
   workflow_dispatch:
     inputs:
       force_report:

--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -10,18 +10,23 @@ on:
     - cron: "0 22-23,0-7 * * *"
     # Crypto: every 15 min 24/7
     - cron: "*/15 * * * *"
-  workflow_dispatch:   # manual trigger from GitHub UI
+  workflow_dispatch:
+    inputs:
+      force_report:
+        description: "Force send daily report (yes/no)"
+        required: false
+        default: "no"
 
 jobs:
 
-  # ── Job 1: Daily paper trading report (sent to email) ─────────────────────
+  # ── Job 1: Daily paper trading report (23:00 Taiwan time = 15:00 UTC) ────────
   paper_trade_report:
-    name: "Paper Trade + Daily Email"
+    name: "Paper Trade + Daily Report"
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Only run on the 09:00 UTC cron or manual dispatch
+    # Only run on the 15:00 UTC daily cron, OR manual dispatch with force_report=yes
     if: >
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.force_report == 'yes') ||
       (github.event_name == 'schedule' &&
        startsWith(github.event.schedule, '0 15'))
 
@@ -61,12 +66,12 @@ jobs:
           path: polymarket_bot/paper_trades.json
           key: paper-state-${{ github.run_id }}
 
-  # ── Job 2: Live scan (real trading, disabled until paper phase is done) ─────
+  # ── Job 2: Live scan (real trading, skips when no private key configured) ────
   live_scan:
     name: "Live Market Scan"
     runs-on: ubuntu-latest
     timeout-minutes: 8
-    # Skip the 09:00 UTC slot (that's paper report time)
+    # Skip the 15:00 UTC slot (that's daily report time); never run on manual dispatch
     if: >
       github.event_name == 'schedule' &&
       !startsWith(github.event.schedule, '0 15')
@@ -95,6 +100,8 @@ jobs:
           POLYMARKET_PRIVATE_KEY: ${{ secrets.POLYMARKET_PRIVATE_KEY }}
           POLYMARKET_FUNDER_ADDRESS: ${{ secrets.POLYMARKET_FUNDER_ADDRESS }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           cd polymarket_bot
           python -c "
@@ -112,7 +119,7 @@ jobs:
           changed = detect_changed_markets(snapshot)
 
           if not changed:
-              print('No price changes — skipping Claude.')
+              print('No price changes — skipping.')
               exit(0)
 
           print(f'{len(changed)} markets changed — evaluating...')
@@ -150,7 +157,19 @@ jobs:
               if place_limit_order(clob, signal, tracker, now):
                   orders += 1
 
-          print(f'Done — signals={signals} orders={orders} | {tracker.summary()}')
+          summary = tracker.summary()
+          print(f'Done — signals={signals} orders={orders} | {summary}')
+
+          if orders > 0:
+              from telegram_reporter import send_message
+              ts = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')
+              msg = (
+                  f'*🔔 Polymarket 實盤成交通知*\n'
+                  f'_{ts}_\n\n'
+                  f'已下單 *{orders}* 筆\\|信號 {signals} 筆\n'
+                  f'{summary}'
+              )
+              send_message(msg)
           "
 
       - name: Save price cache

--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -98,8 +98,12 @@ jobs:
         run: |
           cd polymarket_bot
           python -c "
-          import logging
+          import logging, os
           logging.basicConfig(level=logging.INFO, format='%(asctime)s | %(levelname)s | %(message)s')
+
+          if not os.environ.get('POLYMARKET_PRIVATE_KEY'):
+              print('No POLYMARKET_PRIVATE_KEY configured — paper trading mode, skipping live scan.')
+              exit(0)
 
           from tier1_monitor import fetch_price_snapshot, detect_changed_markets
           from scanner import filter_markets

--- a/polymarket_bot/paper_trader.py
+++ b/polymarket_bot/paper_trader.py
@@ -121,6 +121,14 @@ def check_resolutions(state: dict, markets_by_id: dict) -> list[PaperTrade]:
     return newly_resolved
 
 
+def is_already_open(state: dict, market_id: str) -> bool:
+    """Return True if there is already an unresolved trade for this market."""
+    return any(
+        t["market_id"] == market_id and not t.get("resolved")
+        for t in state["trades"]
+    )
+
+
 def record_paper_trade(state: dict, trade: PaperTrade) -> None:
     state["virtual_bankroll"] -= trade.bet_usdc  # reserve bet amount
     state["trades"].append(asdict(trade))

--- a/polymarket_bot/run_paper_trade.py
+++ b/polymarket_bot/run_paper_trade.py
@@ -33,12 +33,14 @@ from strategy import evaluate_market
 from tracker import Tracker
 from paper_trader import (
     load_state, save_state, check_resolutions,
-    record_paper_trade, PaperTrade, STARTING_BANKROLL,
+    record_paper_trade, is_already_open, PaperTrade, STARTING_BANKROLL,
 )
-from telegram_reporter import send_daily_report
+from telegram_reporter import send_daily_report, send_signal_alert
 
 NICHE_CATEGORIES = {"weather", "science", "entertainment"}
 ESTIMATOR_MODE = os.environ.get("PAPER_ESTIMATOR", "free").lower()
+# SEND_DAILY_REPORT=false → intraday scan mode (no full report, only signal alerts)
+SEND_DAILY_REPORT = os.environ.get("SEND_DAILY_REPORT", "true").lower() == "true"
 
 
 # ── Free heuristic estimator (zero Claude cost) ──────────────────────────────
@@ -112,7 +114,8 @@ class PaperTracker(Tracker):
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 def main() -> None:
-    logger.info("=== Paper trading daily run ===")
+    mode = "daily report" if SEND_DAILY_REPORT else "intraday scan"
+    logger.info(f"=== Paper trading run [{mode}] ===")
     state = load_state()
     tracker = PaperTracker(state)
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
@@ -154,6 +157,9 @@ def main() -> None:
         if signal is None:
             continue
 
+        if is_already_open(state, signal.market_id):
+            continue  # already have a position on this market
+
         trade = PaperTrade(
             date=today,
             market_id=signal.market_id,
@@ -180,12 +186,15 @@ def main() -> None:
     state["last_run"] = today
     save_state(state)
 
-    # Step 5: Send Telegram report
-    send_daily_report(
-        state=state,
-        new_trades=new_trades,
-        newly_resolved=[t.__dict__ for t in newly_resolved],
-    )
+    # Step 5: Notify via Telegram
+    if SEND_DAILY_REPORT:
+        send_daily_report(
+            state=state,
+            new_trades=new_trades,
+            newly_resolved=[t.__dict__ for t in newly_resolved],
+        )
+    elif new_trades:
+        send_signal_alert(new_trades=new_trades, state=state)
 
 
 if __name__ == "__main__":

--- a/polymarket_bot/telegram_reporter.py
+++ b/polymarket_bot/telegram_reporter.py
@@ -148,3 +148,28 @@ def build_daily_report(state: dict, new_trades: list, newly_resolved: list) -> s
 def send_daily_report(state: dict, new_trades: list, newly_resolved: list) -> None:
     msg = build_daily_report(state, new_trades, newly_resolved)
     send_message(msg)
+
+
+def send_signal_alert(new_trades: list, state: dict) -> None:
+    """Brief Telegram alert when intraday scan finds new signals."""
+    bankroll = state["virtual_bankroll"]
+    now = datetime.now(timezone.utc).strftime("%Y\\-%m\\-%d %H:%M UTC")
+    lines = [
+        f"*🆕 模擬新信號 \\({len(new_trades)} 筆\\)*",
+        f"_{now}_",
+        "",
+    ]
+    for t in new_trades[:5]:
+        q = _esc(t.get("question", "")[:45])
+        side = t.get("side", "")
+        price = t.get("price", 0)
+        edge = t.get("edge", 0)
+        bet = t.get("bet_usdc", 0)
+        lines.append(
+            f"• `{side}` @ `{price:.3f}` \\| edge `{edge:.1%}` \\| `${bet:.2f}`\n"
+            f"  _{q}_"
+        )
+    if len(new_trades) > 5:
+        lines.append(f"_\\.\\.\\. 還有 {len(new_trades)-5} 筆_")
+    lines.append(f"\n💰 虛擬餘額　`${bankroll:.2f}`")
+    send_message("\n".join(lines))


### PR DESCRIPTION
## Summary

- **Fix**: `live_scan` job was crashing every 10–15 min with `PolyException: A private key is needed` — added early exit when no private key is set
- **Fix**: `workflow_dispatch` no longer accidentally sends the daily report; now requires `force_report = yes` input
- **New**: `paper_scan` job — scans S5 niche markets every 30 min, sends Telegram alert only when new signals are found
- **New**: Dedup check so the same market is never recorded twice across multiple scan runs
- **New**: `send_signal_alert()` for brief intraday Telegram notifications
- **Fix**: Gmail spam — stops because `live_scan` no longer crashes (GitHub was emailing on every failure)

## Behaviour after merge

| Schedule | Job | Action |
|----------|-----|--------|
| Every 30 min | `paper_scan` | Scan niche markets; Telegram alert only if new signal found |
| Daily 23:00 Taiwan (15:00 UTC) | `paper_trade_report` | Full daily Telegram report |
| Manual dispatch | neither (unless `force_report=yes`) | — |

## Cost (private repo)
2 runs/hour × 24 × 30 = **1,440 min/month** — within the 2,000 free tier. **$0/month.**

## Test plan
- [ ] Merge this PR
- [ ] `paper_scan` runs at :00 and :30 — check Actions tab shows ✅
- [ ] Daily report arrives on Telegram at 23:00 Taiwan time
- [ ] No more failure emails from GitHub

https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein