### PR TITLE
Fix: remove niche pre-filter so markets actually get scanned

### DIFF
--- a/polymarket_bot/run_paper_trade.py
+++ b/polymarket_bot/run_paper_trade.py
@@ -165,37 +165,23 @@ def main() -> None:
             result = "WIN" if t.outcome else "LOSS"
             logger.info(f"  [{result}] {t.question[:50]} | P&L: {t.pnl_usdc:+.2f}")
 
-    # Step 3: Run S5 strategy on niche markets
+    # Step 3: Apply legal filter then scan all markets for edge
     # Legal filter: remove Taiwan politics/elections first
     blocked = [m for m in raw_markets if _is_blocked(m)]
     if blocked:
         logger.info(f"Blocked {len(blocked)} Taiwan politics/election markets")
     raw_markets_clean = [m for m in raw_markets if not _is_blocked(m)]
 
-    # Log actual categories returned by Gamma API (helps debug mismatches)
-    all_cats = {m.get("category", "") or "" for m in raw_markets_clean}
-    logger.info(f"Gamma API categories in batch: {sorted(all_cats)}")
-
-    # Primary: category field match; fallback: keyword in question text
-    NICHE_KEYWORDS = {"weather", "science", "entertainment", "pop culture",
-                      "nature", "climate", "space", "award", "movie", "music",
-                      "celebrity", "tv", "film", "show"}
-
-    def is_niche(m: dict) -> bool:
-        cat = (m.get("category") or "").lower()
-        if cat in NICHE_CATEGORIES:
-            return True
-        if any(kw in cat for kw in NICHE_KEYWORDS):
-            return True
-        question = (m.get("question") or m.get("groupSlug") or "").lower()
-        return any(kw in question for kw in NICHE_KEYWORDS)
-
-    niche_raw = [m for m in raw_markets_clean if is_niche(m)]
-    tradeable = filter_markets(niche_raw)
+    # Apply quality filter (liquidity/spread/binary) to all remaining markets.
+    # Gamma API returns empty category strings, so niche pre-filtering is dropped —
+    # the edge threshold in evaluate_market naturally selects mispriced markets.
+    tradeable = filter_markets(raw_markets_clean)
     logger.info(
-        f"S5 candidates: {len(niche_raw)} niche → {len(tradeable)} tradeable "
+        f"S5 candidates: {len(raw_markets_clean)} total → {len(tradeable)} tradeable "
         f"[estimator={ESTIMATOR_MODE}]"
     )
+
+    niche_raw = tradeable  # kept for compatibility with downstream logging
 
     bankroll = state["virtual_bankroll"]
     new_trades = []


### PR DESCRIPTION
## Problem

Gamma API returns `category=''` for all 800 markets, so the niche pre-filter
produced `0/800 → 0 signals` on every run regardless.

## Fix

Remove the niche category pre-filter entirely. All 800 markets now go through:
1. `_is_blocked()` — Taiwan politics exclusion
2. `filter_markets()` — liquidity / spread / binary quality gate
3. `evaluate_market()` — edge > 8% threshold

The edge threshold is the real quality gate. Niche category was a backtest
convenience that doesn't work when the API returns no categories.

## Test plan
- [ ] Merge this PR
- [ ] Trigger workflow manually (force_report=yes) or wait for next :00/:30
- [ ] Log should show: `S5 candidates: 79X total → N tradeable` (not `0/0`)
- [ ] If any market has edge > 8%, Telegram signal alert sent

https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein

---
_Generated by [Claude Code](https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein)_