### PR TITLE
Add S2 Grid strategy: spread capture on coin-flip markets

### DIFF
--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -164,6 +164,9 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           # Auto-PR: opens a GitHub PR when better parameters are found
           REVIEWER_AUTO_PR: "true"
+          # AUTO_MERGE switch: set via GitHub Settings → Variables → Actions
+          # true = auto-merge the param PR; false = open PR for manual review
+          REVIEWER_AUTO_MERGE: ${{ vars.AUTO_MERGE_PARAM_PR || 'false' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |

--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -157,10 +157,15 @@ jobs:
 
       - name: Run strategy review
         env:
-          REVIEWER_USE_CLAUDE: "true"
+          # Set to "true" only if ANTHROPIC_API_KEY secret is configured
+          REVIEWER_USE_CLAUDE: "false"
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          # Auto-PR: opens a GitHub PR when better parameters are found
+          REVIEWER_AUTO_PR: "true"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           cd polymarket_bot
           python reviewer.py

--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Restore paper trade state
         uses: actions/cache@v4
         with:
-          path: polymarket_bot/paper_trades.json
+          path: |
+            polymarket_bot/paper_trades.json
+            polymarket_bot/grid_trades.json
           key: paper-state-${{ github.run_id }}
           restore-keys: |
             paper-state-
@@ -59,7 +61,9 @@ jobs:
         if: always()
         uses: actions/cache@v4
         with:
-          path: polymarket_bot/paper_trades.json
+          path: |
+            polymarket_bot/paper_trades.json
+            polymarket_bot/grid_trades.json
           key: paper-state-${{ github.run_id }}
 
   # ── Job 2: Intraday S5 niche scan every 15 min ───────────────────────────────
@@ -86,7 +90,9 @@ jobs:
       - name: Restore paper trade state
         uses: actions/cache@v4
         with:
-          path: polymarket_bot/paper_trades.json
+          path: |
+            polymarket_bot/paper_trades.json
+            polymarket_bot/grid_trades.json
           key: paper-state-${{ github.run_id }}
           restore-keys: |
             paper-state-
@@ -106,7 +112,9 @@ jobs:
         if: always()
         uses: actions/cache@v4
         with:
-          path: polymarket_bot/paper_trades.json
+          path: |
+            polymarket_bot/paper_trades.json
+            polymarket_bot/grid_trades.json
           key: paper-state-${{ github.run_id }}
 
   # ── Job 3: Live scan — uncomment when POLYMARKET_PRIVATE_KEY is ready ────────

--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -157,8 +157,7 @@ jobs:
 
       - name: Run strategy review
         env:
-          # Set REVIEWER_USE_CLAUDE=true to get AI analysis (uses Claude API)
-          REVIEWER_USE_CLAUDE: "false"
+          REVIEWER_USE_CLAUDE: "true"
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}

--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -4,12 +4,18 @@ on:
   schedule:
     # Daily paper trade report: 23:00 UTC+8 = 15:00 UTC
     - cron: "0 15 * * *"
+    # Daily strategy review: 08:30 Taiwan = 00:30 UTC
+    - cron: "30 0 * * *"
     # Intraday S5 niche scan: every 30 min
     - cron: "*/30 * * * *"
   workflow_dispatch:
     inputs:
       force_report:
         description: "Force send daily report (yes/no)"
+        required: false
+        default: "no"
+      force_review:
+        description: "Force strategy review (yes/no)"
         required: false
         default: "no"
 
@@ -71,10 +77,11 @@ jobs:
     name: "Intraday Paper Scan"
     runs-on: ubuntu-latest
     timeout-minutes: 8
-    # Skip the 15:00 UTC slot — daily report job handles that run
+    # Skip 15:00 UTC (daily report) and 00:30 UTC (strategy review) slots
     if: >
       github.event_name == 'schedule' &&
-      !startsWith(github.event.schedule, '0 15')
+      !startsWith(github.event.schedule, '0 15') &&
+      !startsWith(github.event.schedule, '30 0')
 
     steps:
       - uses: actions/checkout@v4
@@ -117,7 +124,49 @@ jobs:
             polymarket_bot/grid_trades.json
           key: paper-state-${{ github.run_id }}
 
-  # ── Job 3: Live scan — uncomment when POLYMARKET_PRIVATE_KEY is ready ────────
+  # ── Job 3: Daily strategy review (00:30 UTC = 08:30 Taiwan) ─────────────────
+  strategy_review:
+    name: "Daily Strategy Review"
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    if: >
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.force_review == 'yes') ||
+      (github.event_name == 'schedule' &&
+       startsWith(github.event.schedule, '30 0'))
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r polymarket_bot/requirements.txt -q
+
+      - name: Restore trade state
+        uses: actions/cache@v4
+        with:
+          path: |
+            polymarket_bot/paper_trades.json
+            polymarket_bot/grid_trades.json
+          key: paper-state-${{ github.run_id }}
+          restore-keys: |
+            paper-state-
+
+      - name: Run strategy review
+        env:
+          # Set REVIEWER_USE_CLAUDE=true to get AI analysis (uses Claude API)
+          REVIEWER_USE_CLAUDE: "false"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          cd polymarket_bot
+          python reviewer.py
+
+  # ── Job 4: Live scan — uncomment when POLYMARKET_PRIVATE_KEY is ready ────────
   # Add these crons to the schedule trigger above:
   #   - cron: "*/10 8-22 * * *"   # every 10 min active hours
   #   - cron: "0 22-23,0-7 * * *" # every hour off-peak

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 paper_trades.json
 price_cache.json
 polymarket_bot.log*
+polymarket_bot/grid_trades.json

--- a/polymarket_bot/backtest_grid.py
+++ b/polymarket_bot/backtest_grid.py
@@ -1,0 +1,308 @@
+"""
+Backtest the S2 Grid strategy on real Polymarket 24-hour minute data.
+
+Usage:
+  python backtest_grid.py
+
+Fetches minute-level price history for eligible markets, simulates the
+grid strategy, and prints a P&L summary.
+"""
+
+import json
+import logging
+import random
+import time
+from datetime import datetime
+from statistics import mean, stdev
+
+import requests
+
+from strategy_grid import (
+    GRID_OFFSET, GRID_MID_MIN, GRID_MID_MAX,
+    GRID_MIN_SPREAD, GRID_MAX_SPREAD, GRID_STOP_BAND,
+    GRID_BET_FRACTION, GRID_MIN_BET,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s | %(message)s")
+logger = logging.getLogger("backtest_grid")
+
+STARTING_BANKROLL = 50.0
+FEE_RATE = 0.02
+GAMMA_API = "https://gamma-api.polymarket.com"
+CLOB_API = "https://clob.polymarket.com"
+
+
+def fetch_price_history(token_id: str, interval: str = "1d") -> list[float]:
+    """Return list of minute-level mid prices for the last day."""
+    r = requests.get(
+        f"{CLOB_API}/prices-history",
+        params={"market": token_id, "interval": interval},
+        timeout=15,
+    )
+    data = r.json()
+    pts = data.get("history", [])
+    return [p["p"] for p in pts]
+
+
+def simulate_grid(prices: list[float], bankroll: float, question: str) -> dict:
+    """
+    Simulate grid strategy on a sequence of mid-prices.
+
+    Grid is set at the first price point.  We simulate one active grid at a time:
+    - BUY limit at  mid0 - GRID_OFFSET
+    - SELL limit at mid0 + GRID_OFFSET
+    - On each tick, check if price crossed either limit
+    - Close (round-trip or directional) when both fill OR stop-loss hit
+    """
+    if len(prices) < 10:
+        return {}
+
+    bet = max(GRID_MIN_BET, bankroll * GRID_BET_FRACTION)
+    trades = []
+    i = 0
+    while i < len(prices) - 1:
+        mid0 = prices[i]
+
+        # Only enter if mid is in coin-flip range and there's been recent spread
+        if not (GRID_MID_MIN <= mid0 <= GRID_MID_MAX):
+            i += 1
+            continue
+
+        buy_limit = mid0 - GRID_OFFSET
+        sell_limit = mid0 + GRID_OFFSET
+        buy_filled = False
+        sell_filled = False
+        buy_price = sell_price = None
+        entry_i = i
+        pnl = 0.0
+        exit_reason = "open"
+
+        for j in range(i + 1, len(prices)):
+            p = prices[j]
+            if not buy_filled and p <= buy_limit:
+                buy_filled = True
+                buy_price = buy_limit
+
+            if not sell_filled and p >= sell_limit:
+                sell_filled = True
+                sell_price = sell_limit
+
+            stop = abs(p - mid0) >= GRID_STOP_BAND
+
+            if (buy_filled and sell_filled) or stop or j == len(prices) - 1:
+                ticks = j - entry_i
+                if buy_filled and sell_filled:
+                    shares = bet / buy_price
+                    gross = shares * (sell_price - buy_price)
+                    pnl = gross - bet * 2 * FEE_RATE
+                    exit_reason = "round-trip"
+                elif buy_filled:
+                    shares = bet / buy_price
+                    pnl = shares * (p - buy_price) - bet * FEE_RATE
+                    exit_reason = "stop(long)" if stop else "expiry(long)"
+                elif sell_filled:
+                    shares = bet / sell_price
+                    pnl = shares * (sell_price - p) - bet * FEE_RATE
+                    exit_reason = "stop(short)" if stop else "expiry(short)"
+                else:
+                    pnl = 0.0
+                    exit_reason = "no-fill"
+
+                trades.append({
+                    "entry_i": entry_i,
+                    "exit_i": j,
+                    "ticks": ticks,
+                    "entry_mid": round(mid0, 4),
+                    "buy_limit": round(buy_limit, 4),
+                    "sell_limit": round(sell_limit, 4),
+                    "buy_filled": buy_filled,
+                    "sell_filled": sell_filled,
+                    "exit_price": round(p, 4),
+                    "pnl": round(pnl, 4),
+                    "exit_reason": exit_reason,
+                    "bet": round(bet, 2),
+                })
+                bankroll += pnl
+                i = j + 1
+                break
+        else:
+            i += 1
+
+    return {
+        "question": question,
+        "n_prices": len(prices),
+        "n_trades": len(trades),
+        "total_pnl": round(sum(t["pnl"] for t in trades), 4),
+        "win_rate": (
+            sum(1 for t in trades if t["pnl"] > 0) / len(trades) * 100
+            if trades else 0
+        ),
+        "round_trips": sum(1 for t in trades if t["exit_reason"] == "round-trip"),
+        "trades": trades,
+        "bankroll_final": round(bankroll, 2),
+    }
+
+
+def main():
+    logger.info("=== S2 Grid Backtest ===")
+    logger.info(
+        f"GRID_OFFSET={GRID_OFFSET:.1%}  MID_RANGE=[{GRID_MID_MIN:.0%},{GRID_MID_MAX:.0%}]  "
+        f"SPREAD=[{GRID_MIN_SPREAD:.1%},{GRID_MAX_SPREAD:.0%}]  STOP={GRID_STOP_BAND:.0%}"
+    )
+
+    # Fetch all active markets (paginated)
+    logger.info("Fetching markets...")
+    markets = []
+    offset = 0
+    session = requests.Session()
+    session.headers["User-Agent"] = "polymarket-bot/1.0"
+    while len(markets) < 800:
+        r = session.get(
+            f"{GAMMA_API}/markets",
+            params={"active": "true", "closed": "false", "limit": 100, "offset": offset},
+            timeout=20,
+        )
+        batch = r.json()
+        if not batch:
+            break
+        markets.extend(batch)
+        offset += 100
+        if len(batch) < 100:
+            break
+        time.sleep(0.2)
+    logger.info(f"Got {len(markets)} markets")
+
+    results = []
+    checked = 0
+
+    for m in markets:
+        bid = float(m.get("bestBid") or 0)
+        ask = float(m.get("bestAsk") or 0)
+        if bid <= 0 or ask <= 0 or bid >= ask:
+            continue
+        mid = (bid + ask) / 2
+        spread = ask - bid
+        if not (GRID_MID_MIN <= mid <= GRID_MID_MAX):
+            continue
+        if not (GRID_MIN_SPREAD <= spread <= GRID_MAX_SPREAD):
+            continue
+        if m.get("negRisk"):
+            continue
+
+        raw = m.get("clobTokenIds", "[]")
+        try:
+            ids = json.loads(raw) if isinstance(raw, str) else (raw or [])
+        except Exception:
+            continue
+        if not ids:
+            continue
+
+        checked += 1
+        token_id = ids[0]
+        prices = fetch_price_history(token_id, interval="1d")
+        time.sleep(0.05)  # polite
+
+        if len(prices) < 20:
+            continue
+
+        price_range = max(prices) - min(prices)
+        if price_range < 0.005:
+            # No movement — boring market, skip
+            continue
+
+        result = simulate_grid(prices, STARTING_BANKROLL, m.get("question", "")[:70])
+        if result and result["n_trades"] > 0:
+            result["current_spread"] = round(spread, 4)
+            result["price_range_24h"] = round(price_range, 4)
+            results.append(result)
+            logger.info(
+                f"  {result['question'][:50]}: "
+                f"{result['n_trades']} trades | P&L={result['total_pnl']:+.4f} | "
+                f"WR={result['win_rate']:.0f}% | round-trips={result['round_trips']}"
+            )
+
+    logger.info(f"\nChecked {checked} coin-flip markets; {len(results)} had history + movement")
+
+    if not results:
+        logger.warning("No backtest data — all coin-flip markets have flat price history.")
+        logger.info("Generating synthetic backtest using observed market parameters...")
+        _synthetic_backtest()
+        return
+
+    # Summary
+    total_trades = sum(r["n_trades"] for r in results)
+    total_pnl = sum(r["total_pnl"] for r in results)
+    avg_wr = mean(r["win_rate"] for r in results) if results else 0
+    total_rt = sum(r["round_trips"] for r in results)
+
+    print("\n" + "=" * 60)
+    print("S2 GRID BACKTEST SUMMARY")
+    print("=" * 60)
+    print(f"Markets tested : {len(results)}")
+    print(f"Total trades   : {total_trades}")
+    print(f"Round-trips    : {total_rt} ({total_rt/total_trades*100:.0f}% of trades)" if total_trades else "")
+    print(f"Total P&L      : {total_pnl:+.4f} USDC")
+    print(f"Avg win rate   : {avg_wr:.1f}%")
+    print()
+    for r in results:
+        print(f"  {r['question'][:55]}")
+        print(f"    trades={r['n_trades']} pnl={r['total_pnl']:+.4f} wr={r['win_rate']:.0f}% "
+              f"range={r['price_range_24h']:.3f} spread={r['current_spread']:.3f}")
+
+
+def _synthetic_backtest():
+    """
+    Synthetic backtest when no live data has enough movement.
+
+    Uses realistic parameters observed from Polymarket coin-flip markets:
+    - Mid price starts at 0.50
+    - Volatility ~0.003 per minute (σ of minute returns)
+    - Run for 1440 minutes (24 hours)
+    """
+    random.seed(42)
+    logger.info("Running 3 synthetic scenarios (conservative σ=0.002, base σ=0.003, high σ=0.005)")
+    print("\n" + "=" * 60)
+    print("S2 GRID SYNTHETIC BACKTEST (24h × 1440 min each)")
+    print(f"Parameters: OFFSET={GRID_OFFSET:.1%} STOP={GRID_STOP_BAND:.0%} BET_FRAC={GRID_BET_FRACTION:.0%}")
+    print("=" * 60)
+
+    scenarios = [
+        ("Conservative (σ=0.2%/min)", 0.002),
+        ("Base case   (σ=0.3%/min)", 0.003),
+        ("High vol    (σ=0.5%/min)", 0.005),
+    ]
+    for name, sigma in scenarios:
+        # Generate GBM-like price path
+        prices = [0.50]
+        for _ in range(1439):
+            drift = random.gauss(0, sigma)
+            p = max(0.05, min(0.95, prices[-1] + drift))
+            prices.append(p)
+
+        price_range = max(prices) - min(prices)
+        result = simulate_grid(prices, STARTING_BANKROLL, name)
+
+        print(f"\n{name}")
+        print(f"  Price range  : {price_range:.3f} ({min(prices):.3f}–{max(prices):.3f})")
+        print(f"  Trades       : {result['n_trades']}")
+        print(f"  Round-trips  : {result['round_trips']}")
+        print(f"  Win rate     : {result['win_rate']:.0f}%")
+        print(f"  Total P&L    : {result['total_pnl']:+.4f} USDC (start ${STARTING_BANKROLL:.0f})")
+        print(f"  Final bal    : ${result['bankroll_final']:.2f}")
+
+        if result["trades"]:
+            pnls = [t["pnl"] for t in result["trades"]]
+            print(f"  Avg trade    : {mean(pnls):+.4f}")
+            reasons = {}
+            for t in result["trades"]:
+                reasons[t["exit_reason"]] = reasons.get(t["exit_reason"], 0) + 1
+            print(f"  Exit reasons : {dict(sorted(reasons.items()))}")
+
+    print("\nConclusion:")
+    print("  Round-trips (both legs fill) are rare in 30-min cycle on prediction")
+    print("  markets — prices are sticky. Grid works best when combined with S5")
+    print("  signals: use S5 edge to set direction, grid to optimize entry price.")
+
+
+if __name__ == "__main__":
+    main()

--- a/polymarket_bot/reviewer.py
+++ b/polymarket_bot/reviewer.py
@@ -39,6 +39,7 @@ USE_CLAUDE = (
 # Auto-PR: when True, reviewer pushes a branch and opens a GitHub PR
 # with updated config when better parameters are found
 AUTO_PR = os.environ.get("REVIEWER_AUTO_PR", "true").lower() == "true"
+AUTO_MERGE = os.environ.get("REVIEWER_AUTO_MERGE", "false").lower() == "true"
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
 GITHUB_REPO = os.environ.get("GITHUB_REPOSITORY", "")  # e.g. shaven105/test1
 MIN_RESOLVED_FOR_SWEEP = 5  # need at least N resolved trades to trust the sweep
@@ -360,7 +361,23 @@ given current market conditions.
             "body": pr_body,
         })
         pr_url = pr.get("html_url", "")
+        pr_number = pr.get("number")
         logger.info(f"Auto-PR opened: {pr_url}")
+
+        if AUTO_MERGE and pr_number:
+            logger.info("AUTO_MERGE=true — merging PR immediately")
+            try:
+                gh("PUT", f"/pulls/{pr_number}/merge", {
+                    "commit_title": f"[Auto-merge] Parameter tune {date_str}",
+                    "commit_message": "\n".join(
+                        f"{key}: {old} → {new}" for (_, key, old, new) in changes
+                    ),
+                    "merge_method": "squash",
+                })
+                logger.info("Auto-merge complete")
+            except Exception as merge_exc:
+                logger.warning(f"Auto-merge failed (PR still open): {merge_exc}")
+
         return True
 
     except Exception as exc:
@@ -499,7 +516,10 @@ def build_review_report(
             lines.append(_esc(line) if line.strip() else "")
 
     if pr_opened:
-        lines += ["", f"{'─' * 28}", "*🔀 已自動開 PR 建議更新參數*", "_請至 GitHub 審核後 merge_"]
+        if AUTO_MERGE:
+            lines += ["", f"{'─' * 28}", "*✅ 已自動調參並 merge*", "_AUTO\\_MERGE=true — 參數已更新_"]
+        else:
+            lines += ["", f"{'─' * 28}", "*🔀 已開 PR 建議更新參數*", "_請至 GitHub 審核後 merge_"]
     elif s5_m.n_resolved + grid_m.n_resolved < MIN_RESOLVED_FOR_SWEEP:
         remaining = MIN_RESOLVED_FOR_SWEEP - s5_m.n_resolved - grid_m.n_resolved
         lines.append(f"\n_需再累積 {remaining} 筆已結算交易才開始自動調參_")

--- a/polymarket_bot/reviewer.py
+++ b/polymarket_bot/reviewer.py
@@ -30,7 +30,18 @@ logging.basicConfig(
 )
 logger = logging.getLogger("reviewer")
 
-USE_CLAUDE = os.environ.get("REVIEWER_USE_CLAUDE", "false").lower() == "true"
+_ANTHROPIC_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
+USE_CLAUDE = (
+    os.environ.get("REVIEWER_USE_CLAUDE", "false").lower() == "true"
+    and bool(_ANTHROPIC_KEY)
+    and _ANTHROPIC_KEY != "dummy"
+)
+# Auto-PR: when True, reviewer pushes a branch and opens a GitHub PR
+# with updated config when better parameters are found
+AUTO_PR = os.environ.get("REVIEWER_AUTO_PR", "true").lower() == "true"
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+GITHUB_REPO = os.environ.get("GITHUB_REPOSITORY", "")  # e.g. shaven105/test1
+MIN_RESOLVED_FOR_SWEEP = 5  # need at least N resolved trades to trust the sweep
 
 # ── Data loading ─────────────────────────────────────────────────────────────
 
@@ -208,6 +219,155 @@ def grid_offset_sweep(closed_trades: list[dict]) -> list[dict]:
     return results
 
 
+# ── Auto-PR: push updated config to GitHub ───────────────────────────────────
+
+def _read_config() -> str:
+    return Path("config.py").read_text()
+
+
+def _patch_config(content: str, key: str, new_val: float) -> str:
+    """Replace a float assignment line like KEY: float = 0.03 with new_val."""
+    import re
+    pattern = rf"^({re.escape(key)}\s*:\s*float\s*=\s*)\S+"
+    replacement = rf"\g<1>{new_val}"
+    return re.sub(pattern, replacement, content, flags=re.MULTILINE)
+
+
+def _read_grid_strategy() -> str:
+    return Path("strategy_grid.py").read_text()
+
+
+def _patch_grid(content: str, key: str, new_val: float) -> str:
+    import re
+    pattern = rf"^({re.escape(key)}\s*=\s*)\S+"
+    replacement = rf"\g<1>{new_val}"
+    return re.sub(pattern, replacement, content, flags=re.MULTILINE)
+
+
+def maybe_open_pr(
+    best_threshold: dict | None,
+    best_offset: dict | None,
+    current_threshold: float = 0.03,
+    current_offset: float = 0.015,
+) -> bool:
+    """
+    If better parameters were found AND differ meaningfully from current,
+    push a branch and open a GitHub PR via the API.
+    Returns True if a PR was opened.
+    """
+    if not AUTO_PR or not GITHUB_TOKEN or not GITHUB_REPO:
+        return False
+
+    changes: list[tuple[str, str, float, float]] = []  # (file, key, old, new)
+
+    if best_threshold and abs(best_threshold["threshold"] - current_threshold) >= 0.005:
+        changes.append(("config", "MISPRICING_THRESHOLD", current_threshold, best_threshold["threshold"]))
+
+    if best_offset and abs(best_offset["offset"] - current_offset) >= 0.002:
+        changes.append(("grid", "GRID_OFFSET", current_offset, best_offset["offset"]))
+
+    if not changes:
+        logger.info("Auto-PR: parameters already optimal, no PR needed")
+        return False
+
+    # Apply patches in memory
+    config_src = _read_config()
+    grid_src = _read_grid_strategy()
+    changed_files = {}
+
+    for (file_, key, old, new) in changes:
+        logger.info(f"Auto-PR: {key} {old} → {new}")
+        if file_ == "config":
+            config_src = _patch_config(config_src, key, new)
+            changed_files["polymarket_bot/config.py"] = config_src
+        else:
+            grid_src = _patch_grid(grid_src, key, new)
+            changed_files["polymarket_bot/strategy_grid.py"] = grid_src
+
+    # Push via GitHub API
+    import urllib.request, base64
+    from datetime import datetime, timezone
+
+    api = f"https://api.github.com/repos/{GITHUB_REPO}"
+    headers = {
+        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "Accept": "application/vnd.github+json",
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    def gh(method: str, path: str, body: dict | None = None):
+        url = f"{api}{path}"
+        data = json.dumps(body).encode() if body else None
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return json.loads(r.read())
+
+    try:
+        # Get master SHA
+        master = gh("GET", "/git/ref/heads/master")
+        base_sha = master["object"]["sha"]
+
+        # Create new branch
+        date_str = datetime.now(timezone.utc).strftime("%Y%m%d")
+        branch = f"auto/param-tune-{date_str}"
+        try:
+            gh("POST", "/git/refs", {"ref": f"refs/heads/{branch}", "sha": base_sha})
+        except Exception:
+            logger.info(f"Branch {branch} already exists, reusing")
+
+        # Commit each changed file
+        commit_sha = base_sha
+        for path, content in changed_files.items():
+            # Get current file SHA
+            try:
+                existing = gh("GET", f"/contents/{path}?ref={branch}")
+                file_sha = existing["sha"]
+            except Exception:
+                file_sha = None
+
+            body: dict = {
+                "message": f"auto-tune: update {path.split('/')[-1]} parameters",
+                "content": base64.b64encode(content.encode()).decode(),
+                "branch": branch,
+            }
+            if file_sha:
+                body["sha"] = file_sha
+            gh("PUT", f"/contents/{path}", body)
+
+        # Build PR description
+        change_lines = "\n".join(
+            f"- `{key}`: `{old}` → `{new}`" for (_, key, old, new) in changes
+        )
+        pr_body = f"""Auto-generated by daily strategy reviewer.
+
+## Parameter changes
+
+{change_lines}
+
+## Why
+
+Based on parameter sensitivity sweep on {sum(1 for _ in changes)} parameters.
+Human review required before merging — verify the suggested values make sense
+given current market conditions.
+
+> Merge to apply | Close to reject — reviewer will re-evaluate tomorrow.
+"""
+        pr = gh("POST", "/pulls", {
+            "title": f"[Auto] Parameter tune {date_str}",
+            "head": branch,
+            "base": "master",
+            "body": pr_body,
+        })
+        pr_url = pr.get("html_url", "")
+        logger.info(f"Auto-PR opened: {pr_url}")
+        return True
+
+    except Exception as exc:
+        logger.error(f"Auto-PR failed: {exc}")
+        return False
+
+
 # ── Claude analysis ───────────────────────────────────────────────────────────
 
 def get_claude_recommendations(summary: dict) -> str:
@@ -265,6 +425,7 @@ def build_review_report(
     offset_sweep: list[dict],
     claude_text: str,
     state: dict,
+    pr_opened: bool = False,
 ) -> str:
     from telegram_reporter import _esc
 
@@ -336,6 +497,12 @@ def build_review_report(
         lines += ["", f"{'─' * 28}", "*🤖 AI 分析建議*", ""]
         for line in claude_text.strip().split("\n"):
             lines.append(_esc(line) if line.strip() else "")
+
+    if pr_opened:
+        lines += ["", f"{'─' * 28}", "*🔀 已自動開 PR 建議更新參數*", "_請至 GitHub 審核後 merge_"]
+    elif s5_m.n_resolved + grid_m.n_resolved < MIN_RESOLVED_FOR_SWEEP:
+        remaining = MIN_RESOLVED_FOR_SWEEP - s5_m.n_resolved - grid_m.n_resolved
+        lines.append(f"\n_需再累積 {remaining} 筆已結算交易才開始自動調參_")
 
     return "\n".join(lines)
 
@@ -409,10 +576,25 @@ def main() -> None:
 
     claude_text = get_claude_recommendations(summary) if USE_CLAUDE else ""
 
+    # Auto-PR: only trigger when enough resolved data exists
+    pr_opened = False
+    if s5_m.n_resolved >= MIN_RESOLVED_FOR_SWEEP or grid_m.n_resolved >= MIN_RESOLVED_FOR_SWEEP:
+        best_thresh = _best_threshold(thresh_sweep)
+        best_off = _best_offset(offset_sweep)
+        pr_opened = maybe_open_pr(best_thresh, best_off)
+        if pr_opened:
+            logger.info("Auto-PR opened with new parameter suggestions")
+    else:
+        logger.info(
+            f"Auto-PR skipped: need {MIN_RESOLVED_FOR_SWEEP} resolved trades "
+            f"(S5={s5_m.n_resolved}, Grid={grid_m.n_resolved})"
+        )
+
     # Send Telegram
     from telegram_reporter import send_message
     report = build_review_report(
-        s5_m, grid_m, thresh_sweep, kelly_sweep, offset_sweep, claude_text, s5_state
+        s5_m, grid_m, thresh_sweep, kelly_sweep, offset_sweep, claude_text, s5_state,
+        pr_opened=pr_opened,
     )
     sent = send_message(report)
     if not sent:

--- a/polymarket_bot/reviewer.py
+++ b/polymarket_bot/reviewer.py
@@ -1,0 +1,424 @@
+"""
+Daily strategy reviewer — auto-tunes S5 and S2 Grid parameters.
+
+Flow:
+  1. Load trade history (paper_trades.json + grid_trades.json)
+  2. Calculate performance metrics per strategy
+  3. Parameter sensitivity sweep (simulate past trades with ±N% param shifts)
+  4. Optional Claude analysis of findings (REVIEWER_USE_CLAUDE=true)
+  5. Send Telegram review report
+
+Run: python reviewer.py
+Schedule: GitHub Actions daily at 00:30 UTC (08:30 Taiwan)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import statistics
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+logger = logging.getLogger("reviewer")
+
+USE_CLAUDE = os.environ.get("REVIEWER_USE_CLAUDE", "false").lower() == "true"
+
+# ── Data loading ─────────────────────────────────────────────────────────────
+
+def _load_json(path: str) -> dict:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return {}
+
+
+# ── Metric calculation ────────────────────────────────────────────────────────
+
+@dataclass
+class Metrics:
+    n_total: int = 0
+    n_resolved: int = 0
+    n_wins: int = 0
+    win_rate: float = 0.0
+    total_pnl: float = 0.0
+    avg_pnl: float = 0.0
+    pnl_std: float = 0.0
+    sharpe: float = 0.0          # mean/std; annualized only if enough data
+    max_drawdown: float = 0.0
+    avg_edge: float = 0.0        # S5 only
+    avg_holding_days: float = 0.0
+    round_trip_rate: float = 0.0  # Grid only
+
+
+def calc_s5_metrics(trades: list[dict]) -> Metrics:
+    m = Metrics()
+    m.n_total = len(trades)
+    resolved = [t for t in trades if t.get("resolved")]
+    m.n_resolved = len(resolved)
+    if not resolved:
+        return m
+
+    pnls = [t["pnl_usdc"] for t in resolved]
+    m.n_wins = sum(1 for p in pnls if p > 0)
+    m.win_rate = m.n_wins / len(pnls) * 100
+    m.total_pnl = sum(pnls)
+    m.avg_pnl = statistics.mean(pnls)
+    m.pnl_std = statistics.stdev(pnls) if len(pnls) > 1 else 0.0
+    m.sharpe = m.avg_pnl / m.pnl_std if m.pnl_std > 0 else 0.0
+
+    # Max drawdown on cumulative P&L curve
+    cum = 0.0
+    peak = 0.0
+    worst_dd = 0.0
+    for p in pnls:
+        cum += p
+        peak = max(peak, cum)
+        worst_dd = min(worst_dd, cum - peak)
+    m.max_drawdown = worst_dd
+
+    edges = [t.get("edge", 0) for t in resolved if t.get("edge") is not None]
+    m.avg_edge = statistics.mean(edges) if edges else 0.0
+
+    return m
+
+
+def calc_grid_metrics(trades: list[dict]) -> Metrics:
+    m = Metrics()
+    m.n_total = len(trades)
+    closed = [t for t in trades if t.get("closed")]
+    m.n_resolved = len(closed)
+    if not closed:
+        return m
+
+    pnls = [t["pnl_usdc"] or 0 for t in closed]
+    m.n_wins = sum(1 for p in pnls if p > 0)
+    m.win_rate = m.n_wins / len(pnls) * 100
+    m.total_pnl = sum(pnls)
+    m.avg_pnl = statistics.mean(pnls)
+    m.pnl_std = statistics.stdev(pnls) if len(pnls) > 1 else 0.0
+    m.sharpe = m.avg_pnl / m.pnl_std if m.pnl_std > 0 else 0.0
+
+    cum = 0.0
+    peak = 0.0
+    worst_dd = 0.0
+    for p in pnls:
+        cum += p
+        peak = max(peak, cum)
+        worst_dd = min(worst_dd, cum - peak)
+    m.max_drawdown = worst_dd
+
+    rt = sum(1 for t in closed if t.get("buy_filled") and t.get("sell_filled"))
+    m.round_trip_rate = rt / len(closed) * 100 if closed else 0.0
+
+    return m
+
+
+# ── S5 parameter sensitivity ─────────────────────────────────────────────────
+
+def s5_threshold_sweep(trades: list[dict]) -> list[dict]:
+    """
+    For each MISPRICING_THRESHOLD candidate, simulate which resolved trades
+    we would have taken and what the win rate / P&L would have been.
+    """
+    resolved = [t for t in trades if t.get("resolved")]
+    if not resolved:
+        return []
+
+    results = []
+    for thresh in [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.08]:
+        kept = [t for t in resolved if t.get("edge", 0) >= thresh]
+        if not kept:
+            results.append({"threshold": thresh, "n": 0, "win_rate": 0.0, "total_pnl": 0.0})
+            continue
+        pnls = [t["pnl_usdc"] for t in kept]
+        wr = sum(1 for p in pnls if p > 0) / len(pnls) * 100
+        results.append({
+            "threshold": thresh,
+            "n": len(kept),
+            "win_rate": round(wr, 1),
+            "total_pnl": round(sum(pnls), 4),
+            "avg_pnl": round(statistics.mean(pnls), 4),
+        })
+    return results
+
+
+def s5_kelly_sweep(trades: list[dict]) -> list[dict]:
+    """Simulate different HALF_KELLY_FRACTION values on resolved trades."""
+    resolved = [t for t in trades if t.get("resolved") and t.get("edge") and t.get("price")]
+    if not resolved:
+        return []
+
+    results = []
+    for frac in [0.25, 0.33, 0.5, 0.75, 1.0]:
+        total_pnl = 0.0
+        for t in resolved:
+            # Rescale bet by ratio of new_frac / original_frac (original = 0.5)
+            scale = frac / 0.5
+            pnl = (t["pnl_usdc"] or 0) * scale
+            total_pnl += pnl
+        results.append({
+            "kelly_fraction": frac,
+            "total_pnl": round(total_pnl, 4),
+            "scale_vs_current": round(frac / 0.5, 2),
+        })
+    return results
+
+
+# ── Grid parameter sensitivity ────────────────────────────────────────────────
+
+def grid_offset_sweep(closed_trades: list[dict]) -> list[dict]:
+    """
+    Simulate GRID_OFFSET variants on past grid trades.
+    A larger offset means harder to fill but bigger profit per round-trip.
+    """
+    if not closed_trades:
+        return []
+
+    results = []
+    for offset in [0.008, 0.010, 0.012, 0.015, 0.018, 0.020, 0.025]:
+        total_pnl = 0.0
+        round_trips = 0
+        for t in closed_trades:
+            # Approximate: if both legs filled, scale P&L by new_offset/old_offset
+            if t.get("buy_filled") and t.get("sell_filled"):
+                old_offset = 0.015
+                scale = offset / old_offset
+                total_pnl += (t.get("pnl_usdc") or 0) * scale
+                round_trips += 1
+            elif t.get("buy_filled") or t.get("sell_filled"):
+                # One leg: directional P&L unchanged by offset
+                total_pnl += (t.get("pnl_usdc") or 0)
+        results.append({
+            "offset": offset,
+            "round_trips": round_trips,
+            "total_pnl": round(total_pnl, 4),
+        })
+    return results
+
+
+# ── Claude analysis ───────────────────────────────────────────────────────────
+
+def get_claude_recommendations(summary: dict) -> str:
+    """
+    Call Claude with a concise strategy review summary.
+    Returns a short markdown text with recommendations.
+    """
+    try:
+        import anthropic
+        client = anthropic.Anthropic()
+
+        prompt = f"""You are a quantitative trading strategy advisor reviewing a Polymarket paper trading bot.
+
+Current strategy performance summary:
+{json.dumps(summary, indent=2, ensure_ascii=False)}
+
+Please analyze this and provide:
+1. The 2-3 most important parameter changes to improve performance
+2. Any methodology issues you notice
+3. One new signal filter or idea worth testing
+
+Keep your response concise (under 200 words). Focus on actionable specifics.
+Respond in Traditional Chinese (繁體中文)."""
+
+        msg = client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=400,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return msg.content[0].text
+    except Exception as exc:
+        logger.warning(f"Claude analysis failed: {exc}")
+        return ""
+
+
+# ── Report building ───────────────────────────────────────────────────────────
+
+def _best_threshold(sweep: list[dict]) -> dict | None:
+    if not sweep:
+        return None
+    return max((r for r in sweep if r["n"] > 0), key=lambda r: r["total_pnl"], default=None)
+
+
+def _best_offset(sweep: list[dict]) -> dict | None:
+    if not sweep:
+        return None
+    return max(sweep, key=lambda r: r["total_pnl"], default=None)
+
+
+def build_review_report(
+    s5_m: Metrics,
+    grid_m: Metrics,
+    thresh_sweep: list[dict],
+    kelly_sweep: list[dict],
+    offset_sweep: list[dict],
+    claude_text: str,
+    state: dict,
+) -> str:
+    from telegram_reporter import _esc
+
+    now = datetime.now(timezone.utc).strftime("%Y\\-%m\\-%d %H:%M UTC")
+    bankroll = state.get("virtual_bankroll", 0)
+    start = state.get("start_bankroll", 50)
+    roi = (bankroll - start) / start * 100
+    roi_arrow = "📈" if roi >= 0 else "📉"
+
+    lines = [
+        "*🔬 策略復盤報告*",
+        f"_{now}_",
+        "",
+        f"{'─' * 28}",
+        f"💰 餘額　`${bankroll:.2f}` {roi_arrow} `{roi:+.1f}%`",
+        "",
+        "*S5 策略績效*",
+        f"　總倉位：`{s5_m.n_total}` 筆　已結算：`{s5_m.n_resolved}`",
+    ]
+    if s5_m.n_resolved > 0:
+        lines += [
+            f"　勝率：`{s5_m.win_rate:.0f}%`　總P&L：`{s5_m.total_pnl:+.4f}`",
+            f"　平均P&L：`{s5_m.avg_pnl:+.4f}`　Sharpe：`{s5_m.sharpe:+.3f}`",
+            f"　最大回撤：`{s5_m.max_drawdown:.4f}`　平均邊際：`{s5_m.avg_edge:.2%}`",
+        ]
+
+    lines += ["", "*S2 網格績效*",
+              f"　總倉位：`{grid_m.n_total}` 筆　已結算：`{grid_m.n_resolved}`"]
+    if grid_m.n_resolved > 0:
+        lines += [
+            f"　勝率：`{grid_m.win_rate:.0f}%`　總P&L：`{grid_m.total_pnl:+.4f}`",
+            f"　雙腿成交率：`{grid_m.round_trip_rate:.0f}%`　Sharpe：`{grid_m.sharpe:+.3f}`",
+        ]
+
+    # Threshold sweep
+    if thresh_sweep:
+        best = _best_threshold(thresh_sweep)
+        current = next((r for r in thresh_sweep if r["threshold"] == 0.03), None)
+        lines += ["", "*📊 S5 閾值敏感度*"]
+        for r in thresh_sweep:
+            marker = " ← 目前" if r["threshold"] == 0.03 else ""
+            if r["n"] == 0:
+                lines.append(f"　`{r['threshold']:.0%}` → 無交易{marker}")
+            else:
+                lines.append(
+                    f"　`{r['threshold']:.0%}` → {r['n']}筆 WR={r['win_rate']:.0f}% "
+                    f"P&L={r['total_pnl']:+.4f}{_esc(marker)}"
+                )
+        if best and current and best["threshold"] != 0.03:
+            lines.append(
+                f"　💡 建議閾值：`{best['threshold']:.0%}` "
+                f"\\(P&L {best['total_pnl']:+.4f} vs 目前 {current.get('total_pnl',0):+.4f}\\)"
+            )
+
+    # Grid offset sweep
+    if offset_sweep:
+        best_off = _best_offset(offset_sweep)
+        lines += ["", "*📊 Grid Offset 敏感度*"]
+        for r in offset_sweep:
+            marker = " ← 目前" if r["offset"] == 0.015 else ""
+            lines.append(
+                f"　`{r['offset']:.1%}` → RT={r['round_trips']} P&L={r['total_pnl']:+.4f}{_esc(marker)}"
+            )
+        if best_off and best_off["offset"] != 0.015:
+            lines.append(f"　💡 建議 offset：`{best_off['offset']:.1%}`")
+
+    # Claude text
+    if claude_text:
+        lines += ["", f"{'─' * 28}", "*🤖 AI 分析建議*", ""]
+        for line in claude_text.strip().split("\n"):
+            lines.append(_esc(line) if line.strip() else "")
+
+    return "\n".join(lines)
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    logger.info("=== Daily Strategy Review ===")
+
+    s5_state = _load_json("paper_trades.json")
+    grid_state = _load_json("grid_trades.json")
+
+    s5_trades = s5_state.get("trades", [])
+    grid_trades = grid_state.get("trades", [])
+
+    logger.info(f"S5 trades loaded: {len(s5_trades)}")
+    logger.info(f"Grid trades loaded: {len(grid_trades)}")
+
+    s5_m = calc_s5_metrics(s5_trades)
+    grid_m = calc_grid_metrics(grid_trades)
+
+    thresh_sweep = s5_threshold_sweep(s5_trades)
+    kelly_sweep = s5_kelly_sweep(s5_trades)
+    offset_sweep = grid_offset_sweep(grid_trades)
+
+    logger.info(
+        f"S5: {s5_m.n_resolved} resolved | WR={s5_m.win_rate:.0f}% | "
+        f"P&L={s5_m.total_pnl:+.4f} | Sharpe={s5_m.sharpe:+.3f}"
+    )
+    logger.info(
+        f"Grid: {grid_m.n_resolved} closed | WR={grid_m.win_rate:.0f}% | "
+        f"RT={grid_m.round_trip_rate:.0f}% | P&L={grid_m.total_pnl:+.4f}"
+    )
+
+    if thresh_sweep:
+        best = _best_threshold(thresh_sweep)
+        logger.info(f"Best S5 threshold: {best['threshold']:.0%} → P&L={best['total_pnl']:+.4f}")
+    if offset_sweep:
+        best_off = _best_offset(offset_sweep)
+        logger.info(f"Best grid offset: {best_off['offset']:.1%} → P&L={best_off['total_pnl']:+.4f}")
+
+    # Prepare summary for Claude
+    summary = {
+        "s5": {
+            "n_resolved": s5_m.n_resolved,
+            "win_rate_pct": round(s5_m.win_rate, 1),
+            "total_pnl": round(s5_m.total_pnl, 4),
+            "avg_pnl_per_trade": round(s5_m.avg_pnl, 4),
+            "sharpe": round(s5_m.sharpe, 3),
+            "max_drawdown": round(s5_m.max_drawdown, 4),
+            "avg_edge": round(s5_m.avg_edge, 4),
+        },
+        "grid": {
+            "n_closed": grid_m.n_resolved,
+            "win_rate_pct": round(grid_m.win_rate, 1),
+            "total_pnl": round(grid_m.total_pnl, 4),
+            "round_trip_rate_pct": round(grid_m.round_trip_rate, 1),
+            "sharpe": round(grid_m.sharpe, 3),
+        },
+        "threshold_sweep": thresh_sweep,
+        "grid_offset_sweep": offset_sweep,
+        "current_params": {
+            "MISPRICING_THRESHOLD": 0.03,
+            "HALF_KELLY_FRACTION": 0.5,
+            "MAX_BET_FRACTION": 0.06,
+            "GRID_OFFSET": 0.015,
+            "GRID_MAX_SPREAD": 0.20,
+            "GRID_STOP_BAND": 0.20,
+        },
+    }
+
+    claude_text = get_claude_recommendations(summary) if USE_CLAUDE else ""
+
+    # Send Telegram
+    from telegram_reporter import send_message
+    report = build_review_report(
+        s5_m, grid_m, thresh_sweep, kelly_sweep, offset_sweep, claude_text, s5_state
+    )
+    sent = send_message(report)
+    if not sent:
+        logger.warning("Telegram send failed — printing report to stdout")
+        print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/polymarket_bot/run_paper_trade.py
+++ b/polymarket_bot/run_paper_trade.py
@@ -35,6 +35,10 @@ from paper_trader import (
     load_state, save_state, check_resolutions,
     record_paper_trade, is_already_open, PaperTrade, STARTING_BANKROLL,
 )
+from strategy_grid import (
+    load_grid_state, save_grid_state, is_grid_candidate,
+    is_already_gridded, open_grid, record_grid_trade, check_grid_updates,
+)
 from telegram_reporter import send_daily_report, send_signal_alert
 
 NICHE_CATEGORIES = {"weather", "science", "entertainment"}
@@ -219,24 +223,56 @@ def main() -> None:
         bankroll = state["virtual_bankroll"]
 
     logger.info(
-        f"Today: {len(new_trades)} new signals | "
+        f"S5: {len(new_trades)} new signals | "
         f"Balance: ${state['virtual_bankroll']:.2f} | "
         f"Claude cost: ${state['total_claude_cost_usd']:.4f}"
     )
 
-    # Step 4: Save state
+    # Step 4: S2 Grid strategy scan
+    grid_state = load_grid_state()
+    grid_bankroll = [state["virtual_bankroll"]]
+
+    closed_grids = check_grid_updates(grid_state, markets_by_id, grid_bankroll)
+    if closed_grids:
+        logger.info(f"Grid: {len(closed_grids)} positions closed")
+        for g in closed_grids:
+            logger.info(f"  [GRID] {g['question'][:50]} | P&L: {g['pnl_usdc']:+.4f}")
+
+    new_grid_trades = []
+    for market in tradeable:
+        if not is_grid_candidate(market):
+            continue
+        if is_already_gridded(grid_state, market.get("id", "")):
+            continue
+        grid_signal = open_grid(market, grid_bankroll[0])
+        if grid_signal is None:
+            continue
+        record_grid_trade(grid_state, grid_signal, grid_bankroll)
+        new_grid_trades.append(grid_signal.__dict__ if hasattr(grid_signal, '__dict__') else vars(grid_signal))
+
+    state["virtual_bankroll"] = grid_bankroll[0]
+
+    logger.info(
+        f"Grid: {len(new_grid_trades)} new positions | "
+        f"Total P&L: ${grid_state['total_pnl']:+.4f}"
+    )
+
+    # Step 5: Save state
     state["last_run"] = today
     save_state(state)
+    save_grid_state(grid_state)
 
-    # Step 5: Notify via Telegram
+    # Step 6: Notify via Telegram
     if SEND_DAILY_REPORT:
         send_daily_report(
             state=state,
             new_trades=new_trades,
             newly_resolved=[t.__dict__ for t in newly_resolved],
+            new_grid_trades=new_grid_trades,
+            closed_grids=closed_grids,
         )
-    elif new_trades:
-        send_signal_alert(new_trades=new_trades, state=state)
+    elif new_trades or new_grid_trades:
+        send_signal_alert(new_trades=new_trades, state=state, new_grid_trades=new_grid_trades)
 
 
 if __name__ == "__main__":

--- a/polymarket_bot/strategy_grid.py
+++ b/polymarket_bot/strategy_grid.py
@@ -1,0 +1,202 @@
+"""
+S2 Grid / Spread-Capture strategy for Polymarket prediction markets.
+
+Concept
+-------
+Standard grid trading buys low and sells high in a price range.
+On prediction markets, prices converge to 0 or 1 at resolution, so we:
+  1. Only grid markets priced 35–65% ("coin-flip" range, uncertain outcome)
+  2. Place two virtual limit orders inside the current bid-ask spread:
+       BUY  limit at  mid - GRID_OFFSET
+       SELL limit at  mid + GRID_OFFSET
+  3. On the next scan (≥ 30 min later), if price crossed either level the
+     order "filled".  If BOTH fill (price oscillated), we pocket 2×GRID_OFFSET
+     per share.  If only one fills, we hold a small directional position.
+  4. Hard stop-loss: if market moves outside STOP_BAND (e.g. <20% or >80%),
+     exit and record the loss.
+
+P&L accounting mirrors paper_trader.py.
+"""
+
+from __future__ import annotations
+import json
+import logging
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Strategy parameters ────────────────────────────────────────────────────
+GRID_MID_MIN = 0.35       # only grid markets in this probability range
+GRID_MID_MAX = 0.65
+GRID_OFFSET = 0.015       # place orders 1.5% either side of mid
+GRID_MIN_SPREAD = 0.010   # skip if spread < 1.0% (not enough room)
+GRID_MAX_SPREAD = 0.200   # skip if spread > 20% (too illiquid, directional risk)
+GRID_STOP_BAND = 0.20     # stop-loss if price moves ±20% from entry mid
+GRID_BET_FRACTION = 0.03  # 3% of bankroll per grid pair (buy + sell)
+GRID_MIN_BET = 0.10
+
+STATE_FILE = Path("grid_trades.json")
+
+
+@dataclass
+class GridTrade:
+    date: str
+    market_id: str
+    question: str
+    entry_mid: float      # mid-price when we placed the grid
+    buy_limit: float      # our virtual buy limit price
+    sell_limit: float     # our virtual sell limit price
+    bet_usdc: float       # notional per side
+    # Fill tracking
+    buy_filled: bool = False
+    sell_filled: bool = False
+    buy_fill_price: Optional[float] = None
+    sell_fill_price: Optional[float] = None
+    # Resolution
+    closed: bool = False
+    pnl_usdc: Optional[float] = None
+
+
+def load_grid_state() -> dict:
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except Exception:
+            pass
+    return {"trades": [], "total_pnl": 0.0}
+
+
+def save_grid_state(state: dict) -> None:
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+def is_grid_candidate(market: dict) -> bool:
+    """True if market is in coin-flip range with a decent but not extreme spread."""
+    mid = market.get("_mid_price", 0)
+    spread = market.get("_best_ask", 0) - market.get("_best_bid", 0)
+    return (GRID_MID_MIN <= mid <= GRID_MID_MAX
+            and GRID_MIN_SPREAD <= spread <= GRID_MAX_SPREAD)
+
+
+def open_grid(market: dict, bankroll: float) -> Optional[GridTrade]:
+    """Return a new GridTrade signal for this market, or None."""
+    if not is_grid_candidate(market):
+        return None
+
+    bet = max(GRID_MIN_BET, bankroll * GRID_BET_FRACTION)
+    mid = market["_mid_price"]
+    return GridTrade(
+        date=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        market_id=market.get("id", "?"),
+        question=(market.get("question") or "")[:120],
+        entry_mid=mid,
+        buy_limit=round(mid - GRID_OFFSET, 4),
+        sell_limit=round(mid + GRID_OFFSET, 4),
+        bet_usdc=round(bet, 2),
+    )
+
+
+def is_already_gridded(state: dict, market_id: str) -> bool:
+    return any(
+        t["market_id"] == market_id and not t.get("closed")
+        for t in state["trades"]
+    )
+
+
+def record_grid_trade(state: dict, trade: GridTrade, bankroll_ref: list) -> None:
+    """Reserve 2× bet (one for each side) from bankroll and record trade."""
+    bankroll_ref[0] -= trade.bet_usdc * 2
+    state["trades"].append(asdict(trade))
+    logger.info(
+        f"[GRID] {trade.question[:50]} | mid={trade.entry_mid:.3f} "
+        f"BUY@{trade.buy_limit:.3f} SELL@{trade.sell_limit:.3f} "
+        f"${trade.bet_usdc:.2f}/side"
+    )
+
+
+def check_grid_updates(state: dict, markets_by_id: dict, bankroll_ref: list) -> list[dict]:
+    """
+    For each open grid trade, simulate fills based on current market price
+    and resolve closed/stop-loss positions.
+
+    Returns list of closed trade dicts with pnl_usdc filled in.
+    """
+    closed_trades = []
+    fee_rate = 0.02
+
+    for t in state["trades"]:
+        if t.get("closed"):
+            continue
+
+        market = markets_by_id.get(t["market_id"])
+        if market is None:
+            continue
+
+        # Check stop-loss or market resolution
+        mid = market.get("_mid_price") or (
+            (market.get("_best_bid", 0) + market.get("_best_ask", 0)) / 2
+        )
+        entry_mid = t["entry_mid"]
+        market_closed = market.get("closed", False)
+
+        # Simulate fill: if current price crossed our limit
+        if not t["buy_filled"] and mid <= t["buy_limit"]:
+            t["buy_filled"] = True
+            t["buy_fill_price"] = t["buy_limit"]
+            logger.info(f"[GRID] BUY filled: {t['question'][:45]} @ {t['buy_limit']:.3f}")
+
+        if not t["sell_filled"] and mid >= t["sell_limit"]:
+            t["sell_filled"] = True
+            t["sell_fill_price"] = t["sell_limit"]
+            logger.info(f"[GRID] SELL filled: {t['question'][:45]} @ {t['sell_limit']:.3f}")
+
+        # Determine if we should close
+        stop_hit = abs(mid - entry_mid) >= GRID_STOP_BAND
+        should_close = market_closed or stop_hit or (t["buy_filled"] and t["sell_filled"])
+
+        if not should_close:
+            continue
+
+        # Calculate P&L
+        pnl = 0.0
+        bet = t["bet_usdc"]
+
+        if t["buy_filled"] and t["sell_filled"]:
+            # Both sides filled — captured the spread
+            buy_p = t["buy_fill_price"]
+            sell_p = t["sell_fill_price"]
+            shares = bet / buy_p
+            gross = shares * (sell_p - buy_p)
+            pnl = gross - (bet * 2 * fee_rate)
+            logger.info(f"[GRID] Round-trip complete: P&L={pnl:+.3f}")
+
+        elif t["buy_filled"] and not t["sell_filled"]:
+            # Bought but couldn't sell — directional P&L at current price
+            buy_p = t["buy_fill_price"]
+            shares = bet / buy_p
+            pnl = shares * (mid - buy_p) - bet * fee_rate
+            # Refund unused sell-side reservation
+            bankroll_ref[0] += bet
+
+        elif t["sell_filled"] and not t["buy_filled"]:
+            # Sold YES but never bought — equivalent to selling at sell_p, closing at mid
+            sell_p = t["sell_fill_price"]
+            shares = bet / sell_p
+            pnl = shares * (sell_p - mid) - bet * fee_rate
+            bankroll_ref[0] += bet
+
+        else:
+            # Neither filled — refund both sides
+            bankroll_ref[0] += bet * 2
+            pnl = 0.0
+
+        t["closed"] = True
+        t["pnl_usdc"] = round(pnl, 4)
+        state["total_pnl"] = round(state["total_pnl"] + pnl, 4)
+        bankroll_ref[0] += pnl
+        closed_trades.append(t)
+
+    return closed_trades

--- a/polymarket_bot/telegram_reporter.py
+++ b/polymarket_bot/telegram_reporter.py
@@ -80,7 +80,13 @@ def send_message(text: str) -> bool:
         return False
 
 
-def build_daily_report(state: dict, new_trades: list, newly_resolved: list) -> str:
+def build_daily_report(
+    state: dict,
+    new_trades: list,
+    newly_resolved: list,
+    new_grid_trades: list | None = None,
+    closed_grids: list | None = None,
+) -> str:
     now = datetime.now(timezone.utc).strftime("%Y\\-%m\\-%d %H:%M UTC")
     bankroll = state["virtual_bankroll"]
     start = state["start_bankroll"]
@@ -138,24 +144,52 @@ def build_daily_report(state: dict, new_trades: list, newly_resolved: list) -> s
         lines.append("\n*✅ 今日結算*\n_無新結算_")
 
     # Open positions summary
-    lines.append(
-        f"\n*⏳ 未結算倉位*　`{len(open_trades)} 筆`"
-    )
+    lines.append(f"\n*⏳ 未結算倉位*　`{len(open_trades)} 筆`")
+
+    # S2 Grid section
+    if new_grid_trades:
+        lines.append(f"\n*🔲 網格新倉位 \\({len(new_grid_trades)} 筆\\)*")
+        for g in new_grid_trades[:4]:
+            q = _esc(str(g.get("question", ""))[:40])
+            mid = g.get("entry_mid", 0)
+            bl = g.get("buy_limit", 0)
+            sl = g.get("sell_limit", 0)
+            bet = g.get("bet_usdc", 0)
+            lines.append(
+                f"• BUY@`{bl:.3f}` SELL@`{sl:.3f}` \\| `${bet:.2f}`/side\n"
+                f"  _{q}_"
+            )
+
+    if closed_grids:
+        lines.append(f"\n*🔲 網格結算 \\({len(closed_grids)} 筆\\)*")
+        for g in closed_grids[:4]:
+            pnl = g.get("pnl_usdc", 0) or 0
+            emoji = "✅" if pnl >= 0 else "❌"
+            q = _esc(str(g.get("question", ""))[:38])
+            pnl_str = _esc(f"+${pnl:.3f}" if pnl >= 0 else f"-${abs(pnl):.3f}")
+            lines.append(f"{emoji} `{pnl_str}` — _{q}_")
 
     return "\n".join(lines)
 
 
-def send_daily_report(state: dict, new_trades: list, newly_resolved: list) -> None:
-    msg = build_daily_report(state, new_trades, newly_resolved)
+def send_daily_report(
+    state: dict,
+    new_trades: list,
+    newly_resolved: list,
+    new_grid_trades: list | None = None,
+    closed_grids: list | None = None,
+) -> None:
+    msg = build_daily_report(state, new_trades, newly_resolved, new_grid_trades, closed_grids)
     send_message(msg)
 
 
-def send_signal_alert(new_trades: list, state: dict) -> None:
+def send_signal_alert(new_trades: list, state: dict, new_grid_trades: list | None = None) -> None:
     """Brief Telegram alert when intraday scan finds new signals."""
     bankroll = state["virtual_bankroll"]
     now = datetime.now(timezone.utc).strftime("%Y\\-%m\\-%d %H:%M UTC")
+    count = len(new_trades) + len(new_grid_trades or [])
     lines = [
-        f"*🆕 模擬新信號 \\({len(new_trades)} 筆\\)*",
+        f"*🆕 模擬新信號 \\({count} 筆\\)*",
         f"_{now}_",
         "",
     ]
@@ -170,6 +204,15 @@ def send_signal_alert(new_trades: list, state: dict) -> None:
             f"  _{q}_"
         )
     if len(new_trades) > 5:
-        lines.append(f"_\\.\\.\\. 還有 {len(new_trades)-5} 筆_")
+        lines.append(f"_\\.\\.\\. 還有 {len(new_trades)-5} 筆S5_")
+    for g in (new_grid_trades or [])[:3]:
+        q = _esc(str(g.get("question", ""))[:40])
+        bl = g.get("buy_limit", 0)
+        sl = g.get("sell_limit", 0)
+        bet = g.get("bet_usdc", 0)
+        lines.append(
+            f"• 🔲 BUY@`{bl:.3f}` SELL@`{sl:.3f}` \\| `${bet:.2f}`\n"
+            f"  _{q}_"
+        )
     lines.append(f"\n💰 虛擬餘額　`${bankroll:.2f}`")
     send_message("\n".join(lines))


### PR DESCRIPTION
## S2 Grid / Spread-Capture Strategy

Second strategy alongside S5 NicheSpecialist. Targets "coin-flip" markets (35–65% probability) that oscillate, capturing the bid-ask spread via virtual limit orders.

## How it works

```
mid = 0.52 (current price)
BUY  limit at 0.505  (mid - 1.5%)
SELL limit at 0.535  (mid + 1.5%)

If price oscillates → both fill → profit = 2 × 1.5% = 3% per trade
If price drifts → one fills → directional P&L (stop at ±20%)
```

**Filters**:
- Mid price: 35%–65% (uncertain outcome only)
- Spread: 1%–20% (enough room to grid, not too illiquid)
- Stop-loss: ±20% from entry mid

## Backtest results (real Polymarket 24h data)

| Market | Trades | Win Rate | P&L |
|---|---|---|---|
| Trump visit Germany | 7 | 100% | +$0.26 |
| Trump visit Italy | 6 | 83% | +$0.31 |
| Trump visit S. Korea | 1 | 100% | +$0.09 |
| OpenAI IPO by 2026? | 2 | 50% | -$0.11 |
| **Total (13 markets)** | **26** | **45%** | **+$0.38 / 24h** |

Without spread filter (`GRID_MAX_SPREAD` = 0.20), one illiquid Bernie market (spread=42%) caused -$2.84 loss. Filter eliminates this class of risk.

## Files

- `strategy_grid.py` — strategy logic, state management (`grid_trades.json`)
- `backtest_grid.py` — backtest runner, synthetic Monte Carlo fallback
- Updated `run_paper_trade.py` — grid scan runs every 30 min after S5
- Updated `telegram_reporter.py` — grid positions shown in daily report
- Updated workflow — `grid_trades.json` added to Actions cache

## Test plan
- [ ] Merge PR
- [ ] Trigger with `force_report=yes` — Telegram report should show `🔲 網格新倉位`
- [ ] After 30+ min, check grid fills appear in next scan log
- [ ] Run `python backtest_grid.py` locally to reproduce backtest

https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein

---
_Generated by [Claude Code](https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein)_