### PR TITLE
S3 Sniper v3.1: Resolution Lag architecture, $100 bankroll reset, dual-scan cadence

### DIFF
--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -78,7 +78,7 @@ jobs:
   paper_scan:
     name: "Intraday Paper Scan"
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 12
     # Skip 15:00 UTC (daily report) and 00:30 UTC (strategy review) slots
     if: >
       github.event_name == 'schedule' &&
@@ -117,11 +117,14 @@ jobs:
         env:
           PAPER_ESTIMATOR: free
           SEND_DAILY_REPORT: "false"
+          MONTHLY_SCAN_LIMIT: ${{ vars.MONTHLY_SCAN_LIMIT || '1200' }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           cd polymarket_bot
+          python run_paper_trade.py
+          sleep 120
           python run_paper_trade.py
 
       - name: Save paper trade state

--- a/.github/workflows/polymarket_bot.yml
+++ b/.github/workflows/polymarket_bot.yml
@@ -49,9 +49,9 @@ jobs:
             polymarket_bot/paper_trades.json
             polymarket_bot/grid_trades.json
             polymarket_bot/sniper_trades.json
-          key: paper-state-${{ github.run_id }}
+          key: paper-state-v2-${{ github.run_id }}
           restore-keys: |
-            paper-state-
+            paper-state-v2-
 
       - name: Run paper trade + send Telegram daily report
         env:
@@ -72,7 +72,7 @@ jobs:
             polymarket_bot/paper_trades.json
             polymarket_bot/grid_trades.json
             polymarket_bot/sniper_trades.json
-          key: paper-state-${{ github.run_id }}
+          key: paper-state-v2-${{ github.run_id }}
 
   # ── Job 2: Intraday scan every 5 min ─────────────────────────────────────────
   paper_scan:
@@ -109,9 +109,9 @@ jobs:
             polymarket_bot/paper_trades.json
             polymarket_bot/grid_trades.json
             polymarket_bot/sniper_trades.json
-          key: paper-state-${{ github.run_id }}
+          key: paper-state-v2-${{ github.run_id }}
           restore-keys: |
-            paper-state-
+            paper-state-v2-
 
       - name: Scan markets + alert on new signals
         env:
@@ -132,7 +132,7 @@ jobs:
             polymarket_bot/paper_trades.json
             polymarket_bot/grid_trades.json
             polymarket_bot/sniper_trades.json
-          key: paper-state-${{ github.run_id }}
+          key: paper-state-v2-${{ github.run_id }}
 
   # ── Job 3: Daily strategy review (00:30 UTC = 08:30 Taiwan) ─────────────────
   strategy_review:
@@ -162,9 +162,9 @@ jobs:
             polymarket_bot/paper_trades.json
             polymarket_bot/grid_trades.json
             polymarket_bot/sniper_trades.json
-          key: paper-state-${{ github.run_id }}
+          key: paper-state-v2-${{ github.run_id }}
           restore-keys: |
-            paper-state-
+            paper-state-v2-
 
       - name: Run strategy review
         env:
@@ -188,7 +188,7 @@ jobs:
             polymarket_bot/paper_trades.json
             polymarket_bot/grid_trades.json
             polymarket_bot/sniper_trades.json
-          key: paper-state-${{ github.run_id }}
+          key: paper-state-v2-${{ github.run_id }}
 
   # ── Job 4: Live scan — uncomment when POLYMARKET_PRIVATE_KEY is ready ────────
   # live_scan:

--- a/polymarket_bot/backtest_sniper.py
+++ b/polymarket_bot/backtest_sniper.py
@@ -204,9 +204,10 @@ def run_real_backtest() -> bool:
             continue
 
         live_price = float(live_price_raw)
-        outcome = _verify_crypto_outcome(live_price, threshold, direction)
-        if not outcome:
+        verified = _verify_crypto_outcome(live_price, threshold, direction)
+        if not verified:
             continue  # live price too close to threshold to verify
+        outcome, _confidence = verified
 
         # Find the entry point in price history
         entry_window = end_ts - 48 * 3600

--- a/polymarket_bot/config.py
+++ b/polymarket_bot/config.py
@@ -31,7 +31,7 @@ MIN_BEST_BID: float = 0.03             # skip near-certainties
 MAX_BEST_ASK: float = 0.97
 
 # Strategy
-MISPRICING_THRESHOLD: float = 0.03    # 3% minimum edge (free heuristic; raise to 8% for live Claude mode)
+MISPRICING_THRESHOLD: float = 0.05    # 5% minimum edge (free heuristic; raise to 8% for live Claude mode)
 HALF_KELLY_FRACTION: float = 0.5
 MAX_BET_FRACTION: float = 0.06        # hard cap: 6% of bankroll per trade
 MIN_BET_USDC: float = 0.10            # paper trading min; CLOB live minimum is $15

--- a/polymarket_bot/paper_trader.py
+++ b/polymarket_bot/paper_trader.py
@@ -1,12 +1,9 @@
 """
-Paper trading engine for S5 NicheSpecialist strategy.
+Paper trading engine — virtual portfolio backed by paper_trades.json.
 
-Maintains a virtual portfolio in paper_trades.json:
-- Virtual bankroll starts at $50
-- Scans real Polymarket data, finds real signals
-- Records what would have been traded (no real orders)
-- On subsequent runs, checks if previously recorded markets have resolved
-- Calculates P&L when resolution is detected
+Virtual bankroll starts at $100 (reset June 2026 — v2 experiment).
+Only S3 Sniper positions are recorded here now; S5 NicheSpecialist trades
+are legacy and will resolve naturally as markets close.
 """
 
 import json
@@ -19,7 +16,7 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 STATE_FILE = Path("paper_trades.json")
-STARTING_BANKROLL = 50.0
+STARTING_BANKROLL = 100.0
 
 
 @dataclass

--- a/polymarket_bot/run_paper_trade.py
+++ b/polymarket_bot/run_paper_trade.py
@@ -3,20 +3,18 @@ Daily paper trading runner — called by GitHub Actions.
 
 Flow:
   1. Fetch real Polymarket markets (Gamma API)
-  2. Check if any previously recorded markets have resolved → update P&L
-  3. Run S5 NicheSpecialist strategy on today's markets → record new signals
-  4. Send HTML email report
+  2. Resolve any open S5/S2/S3 positions → update P&L
+  3. Run S3 Sniper v3 (Kelly-sized, crypto + sports verified) → record new signals
+  4. Send Telegram report
   5. Save updated state
 
-Estimator modes (set PAPER_ESTIMATOR env var):
-  "free"   (default) — bias-corrected mid-price heuristic, zero Claude cost
-  "claude"           — real Claude API calls (~$0.65–2/day)
+S5 (NicheSpecialist) and S2 (Grid) new entries are permanently suspended.
+All capital is allocated to S3 Sniper targeting MoM 20% returns.
+Existing open S5/S2 positions continue to resolve normally.
 """
 
-import json
 import logging
 import os
-import random
 from datetime import datetime, timezone
 
 logging.basicConfig(
@@ -28,37 +26,18 @@ logger = logging.getLogger("paper_trade")
 
 # ── Import bot modules ──────────────────────────────────────────────────────
 
-from scanner import fetch_active_markets, filter_markets
-from strategy import evaluate_market
-from tracker import Tracker
-from paper_trader import (
-    load_state, save_state, check_resolutions,
-    record_paper_trade, is_already_open, PaperTrade, STARTING_BANKROLL,
-)
-from strategy_grid import (
-    load_grid_state, save_grid_state, is_grid_candidate,
-    is_already_gridded, open_grid, record_grid_trade, check_grid_updates,
-)
+from scanner import fetch_active_markets
+from paper_trader import load_state, save_state, check_resolutions
+from strategy_grid import load_grid_state, save_grid_state, check_grid_updates
 from strategy_sniper import (
-    load_sniper_state, save_sniper_state, is_already_sniped,
+    load_sniper_state, save_sniper_state,
     find_sniper_candidates, record_sniper_trade, check_sniper_resolutions,
-    fetch_crypto_prices,
+    fetch_crypto_prices, fetch_sports_results,
 )
 from telegram_reporter import send_daily_report, send_signal_alert
 
-NICHE_CATEGORIES = {"weather", "science", "entertainment"}
-ESTIMATOR_MODE = os.environ.get("PAPER_ESTIMATOR", "free").lower()
 # SEND_DAILY_REPORT=false → intraday scan mode (no full report, only signal alerts)
 SEND_DAILY_REPORT = os.environ.get("SEND_DAILY_REPORT", "true").lower() == "true"
-
-# ── Capital protection thresholds ─────────────────────────────────────────────
-# With only $50, running multiple long-horizon strategies simultaneously burns
-# runway before any returns materialise. Gate strategies by remaining capital:
-#   > $30 (60%): all 3 strategies active
-#   $20–30 (40–60%): suspend Grid (S2) — long lock-up, high noise
-#   < $20 (40%): suspend S5 + Grid, keep only Sniper (S3, 48h cycle, 97% WR)
-CAPITAL_GATE_GRID = 30.0   # suspend Grid below this balance
-CAPITAL_GATE_S5   = 20.0   # suspend S5 below this balance
 
 # ── Legal exclusion: Taiwan politics / elections ──────────────────────────────
 # Blocked for legal compliance — do not trade on these markets.
@@ -95,81 +74,12 @@ def _is_blocked(market: dict) -> bool:
     return any(kw in text for kw in _TW_BLOCKED_KEYWORDS)
 
 
-# ── Free heuristic estimator (zero Claude cost) ──────────────────────────────
-
-def _free_estimate(market: dict) -> float:
-    """
-    Bias-corrected mid-price estimator — no API cost.
-
-    Applies two known Polymarket biases:
-    1. Favorite-longshot: prices <25% are overpriced ~4%, prices >75% underpriced ~3%
-    2. Niche market noise: extra ±3% random correction (wider mispricings expected)
-
-    This won't be as accurate as Claude but is good enough to identify
-    directional signals for observation purposes.
-    """
-    bid = float(market.get("_best_bid") or market.get("bestBid") or 0)
-    ask = float(market.get("_best_ask") or market.get("bestAsk") or 0)
-    if bid <= 0 or ask <= 0:
-        return 0.5
-    mid = (bid + ask) / 2.0
-
-    # Longshot bias correction
-    if mid < 0.25:
-        mid = min(mid + 0.04 * (0.25 - mid) / 0.25, 0.95)
-    elif mid > 0.75:
-        mid = max(mid - 0.03 * (mid - 0.75) / 0.25, 0.05)
-
-    # Niche market extra noise (wider spread = more uncertainty)
-    spread = ask - bid
-    if spread > 0.06:
-        mid += random.gauss(0, spread * 0.3)
-
-    return max(0.04, min(0.96, mid))
-
-
-def get_fair_probability(market: dict, tracker) -> float | None:
-    """Route to free heuristic or real Claude depending on PAPER_ESTIMATOR."""
-    if ESTIMATOR_MODE == "claude":
-        from valuator import estimate_fair_probability
-        return estimate_fair_probability(market, tracker)
-    return _free_estimate(market)
-
-
-# ── Fake CLOB client for paper trading (no real orders) ─────────────────────
-
-class PaperClobClient:
-    def get_balance(self):
-        state = load_state()
-        return str(state["virtual_bankroll"])
-
-
-class PaperTracker(Tracker):
-    def __init__(self, state: dict):
-        self._state = state
-        self._clob = PaperClobClient()
-        self.cumulative_claude_cost_usd = state["total_claude_cost_usd"]
-        self.realized_pnl_usdc = state["total_realized_pnl"]
-        self.open_trades = []
-        self._cached_balance = state["virtual_bankroll"]
-
-    def record_claude_usage(self, input_tokens: int, output_tokens: int) -> float:
-        cost = super().record_claude_usage(input_tokens, output_tokens)
-        self._state["total_claude_cost_usd"] = self.cumulative_claude_cost_usd
-        return cost
-
-    def get_usdc_balance(self) -> float:
-        self._cached_balance = self._state["virtual_bankroll"]
-        return self._cached_balance
-
-
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 def main() -> None:
     mode = "daily report" if SEND_DAILY_REPORT else "intraday scan"
     logger.info(f"=== Paper trading run [{mode}] ===")
     state = load_state()
-    tracker = PaperTracker(state)
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     # Step 1: Fetch markets
@@ -185,69 +95,19 @@ def main() -> None:
             result = "WIN" if t.outcome else "LOSS"
             logger.info(f"  [{result}] {t.question[:50]} | P&L: {t.pnl_usdc:+.2f}")
 
-    # Step 3: Apply legal filter then scan all markets for edge
-    # Legal filter: remove Taiwan politics/elections first
+    # Step 3: Apply legal filter
     blocked = [m for m in raw_markets if _is_blocked(m)]
     if blocked:
         logger.info(f"Blocked {len(blocked)} Taiwan politics/election markets")
     raw_markets_clean = [m for m in raw_markets if not _is_blocked(m)]
 
-    # Apply quality filter (liquidity/spread/binary) to all remaining markets.
-    # Gamma API returns empty category strings, so niche pre-filtering is dropped —
-    # the edge threshold in evaluate_market naturally selects mispriced markets.
-    tradeable = filter_markets(raw_markets_clean)
+    # S5 (NicheSpecialist) and S2 (Grid) new entries are suspended — all capital
+    # is allocated to S3 Sniper (Kelly-sized, externally verified, 97%+ WR).
+    # Resolution of existing open S5/S2 positions still runs below.
+    new_trades: list = []
     logger.info(
-        f"S5 candidates: {len(raw_markets_clean)} total → {len(tradeable)} tradeable "
-        f"[estimator={ESTIMATOR_MODE}]"
-    )
-
-    niche_raw = tradeable  # kept for compatibility with downstream logging
-
-    bankroll = state["virtual_bankroll"]
-    new_trades = []
-
-    if bankroll < CAPITAL_GATE_S5:
-        logger.warning(
-            f"Balance ${bankroll:.2f} < ${CAPITAL_GATE_S5} capital gate — "
-            f"S5 suspended. Only S3 Sniper active."
-        )
-    else:
-        for market in tradeable:
-            if bankroll <= 1.0:
-                logger.warning("Virtual bankroll too low — stopping paper scan")
-                break
-
-            fair = get_fair_probability(market, tracker)
-            if fair is None:
-                continue
-
-            signal = evaluate_market(market, fair, bankroll)
-            if signal is None:
-                continue
-
-            if is_already_open(state, signal.market_id):
-                continue  # already have a position on this market
-
-            trade = PaperTrade(
-                date=today,
-                market_id=signal.market_id,
-                question=signal.market_question,
-                category=market.get("category", ""),
-                side=signal.side_label,
-                price=signal.market_price,
-                fair_prob=signal.fair_prob,
-                edge=signal.edge,
-                bet_usdc=round(signal.bet_usdc, 2),
-                shares=round(signal.bet_usdc / signal.market_price, 2),
-            )
-            record_paper_trade(state, trade)
-            new_trades.append(trade.__dict__)
-            bankroll = state["virtual_bankroll"]
-
-    logger.info(
-        f"S5: {len(new_trades)} new signals | "
-        f"Balance: ${state['virtual_bankroll']:.2f} | "
-        f"Claude cost: ${state['total_claude_cost_usd']:.4f}"
+        f"S5 suspended (MoM 20% target via S3 only) | "
+        f"Balance: ${state['virtual_bankroll']:.2f}"
     )
 
     # Step 4: S2 Grid strategy scan
@@ -260,28 +120,12 @@ def main() -> None:
         for g in closed_grids:
             logger.info(f"  [GRID] {g['question'][:50]} | P&L: {g['pnl_usdc']:+.4f}")
 
-    new_grid_trades = []
-    if grid_bankroll[0] < CAPITAL_GATE_GRID:
-        logger.warning(
-            f"Balance ${grid_bankroll[0]:.2f} < ${CAPITAL_GATE_GRID} capital gate — "
-            f"Grid suspended. No new positions opened."
-        )
-    else:
-        for market in tradeable:
-            if not is_grid_candidate(market):
-                continue
-            if is_already_gridded(grid_state, market.get("id", "")):
-                continue
-            grid_signal = open_grid(market, grid_bankroll[0])
-            if grid_signal is None:
-                continue
-            record_grid_trade(grid_state, grid_signal, grid_bankroll)
-            new_grid_trades.append(grid_signal.__dict__ if hasattr(grid_signal, '__dict__') else vars(grid_signal))
-
+    # Grid new entries suspended — only resolving existing positions
+    new_grid_trades: list = []
     state["virtual_bankroll"] = grid_bankroll[0]
 
     logger.info(
-        f"Grid: {len(new_grid_trades)} new positions | "
+        f"Grid suspended (S2 new entries off) | "
         f"Total P&L: ${grid_state['total_pnl']:+.4f}"
     )
 
@@ -294,10 +138,12 @@ def main() -> None:
     if closed_snipers:
         logger.info(f"Sniper: {len(closed_snipers)} positions resolved")
 
-    # Fetch crypto prices once for all sniper candidates
+    # Fetch external price/result data for S3 Sniper verification
     crypto_prices = fetch_crypto_prices()
     if crypto_prices:
         logger.info(f"Crypto prices fetched: {list(crypto_prices.keys())}")
+
+    sports_results = fetch_sports_results()
 
     # Scan all legal markets (not just tradeable) to catch more near-expiry candidates
     new_sniper_trades = []
@@ -306,6 +152,7 @@ def main() -> None:
         bankroll=sniper_bankroll[0],
         sniper_state=sniper_state,
         crypto_prices=crypto_prices,
+        sports_results=sports_results,
     )
     for signal in sniper_candidates:
         if sniper_bankroll[0] < signal.bet_usdc:

--- a/polymarket_bot/run_paper_trade.py
+++ b/polymarket_bot/run_paper_trade.py
@@ -51,6 +51,15 @@ ESTIMATOR_MODE = os.environ.get("PAPER_ESTIMATOR", "free").lower()
 # SEND_DAILY_REPORT=false → intraday scan mode (no full report, only signal alerts)
 SEND_DAILY_REPORT = os.environ.get("SEND_DAILY_REPORT", "true").lower() == "true"
 
+# ── Capital protection thresholds ─────────────────────────────────────────────
+# With only $50, running multiple long-horizon strategies simultaneously burns
+# runway before any returns materialise. Gate strategies by remaining capital:
+#   > $30 (60%): all 3 strategies active
+#   $20–30 (40–60%): suspend Grid (S2) — long lock-up, high noise
+#   < $20 (40%): suspend S5 + Grid, keep only Sniper (S3, 48h cycle, 97% WR)
+CAPITAL_GATE_GRID = 30.0   # suspend Grid below this balance
+CAPITAL_GATE_S5   = 20.0   # suspend S5 below this balance
+
 # ── Legal exclusion: Taiwan politics / elections ──────────────────────────────
 # Blocked for legal compliance — do not trade on these markets.
 _TW_BLOCKED_KEYWORDS = {
@@ -197,37 +206,43 @@ def main() -> None:
     bankroll = state["virtual_bankroll"]
     new_trades = []
 
-    for market in tradeable:
-        if bankroll <= 1.0:
-            logger.warning("Virtual bankroll too low — stopping paper scan")
-            break
-
-        fair = get_fair_probability(market, tracker)
-        if fair is None:
-            continue
-
-        signal = evaluate_market(market, fair, bankroll)
-        if signal is None:
-            continue
-
-        if is_already_open(state, signal.market_id):
-            continue  # already have a position on this market
-
-        trade = PaperTrade(
-            date=today,
-            market_id=signal.market_id,
-            question=signal.market_question,
-            category=market.get("category", ""),
-            side=signal.side_label,
-            price=signal.market_price,
-            fair_prob=signal.fair_prob,
-            edge=signal.edge,
-            bet_usdc=round(signal.bet_usdc, 2),
-            shares=round(signal.bet_usdc / signal.market_price, 2),
+    if bankroll < CAPITAL_GATE_S5:
+        logger.warning(
+            f"Balance ${bankroll:.2f} < ${CAPITAL_GATE_S5} capital gate — "
+            f"S5 suspended. Only S3 Sniper active."
         )
-        record_paper_trade(state, trade)
-        new_trades.append(trade.__dict__)
-        bankroll = state["virtual_bankroll"]
+    else:
+        for market in tradeable:
+            if bankroll <= 1.0:
+                logger.warning("Virtual bankroll too low — stopping paper scan")
+                break
+
+            fair = get_fair_probability(market, tracker)
+            if fair is None:
+                continue
+
+            signal = evaluate_market(market, fair, bankroll)
+            if signal is None:
+                continue
+
+            if is_already_open(state, signal.market_id):
+                continue  # already have a position on this market
+
+            trade = PaperTrade(
+                date=today,
+                market_id=signal.market_id,
+                question=signal.market_question,
+                category=market.get("category", ""),
+                side=signal.side_label,
+                price=signal.market_price,
+                fair_prob=signal.fair_prob,
+                edge=signal.edge,
+                bet_usdc=round(signal.bet_usdc, 2),
+                shares=round(signal.bet_usdc / signal.market_price, 2),
+            )
+            record_paper_trade(state, trade)
+            new_trades.append(trade.__dict__)
+            bankroll = state["virtual_bankroll"]
 
     logger.info(
         f"S5: {len(new_trades)} new signals | "
@@ -246,16 +261,22 @@ def main() -> None:
             logger.info(f"  [GRID] {g['question'][:50]} | P&L: {g['pnl_usdc']:+.4f}")
 
     new_grid_trades = []
-    for market in tradeable:
-        if not is_grid_candidate(market):
-            continue
-        if is_already_gridded(grid_state, market.get("id", "")):
-            continue
-        grid_signal = open_grid(market, grid_bankroll[0])
-        if grid_signal is None:
-            continue
-        record_grid_trade(grid_state, grid_signal, grid_bankroll)
-        new_grid_trades.append(grid_signal.__dict__ if hasattr(grid_signal, '__dict__') else vars(grid_signal))
+    if grid_bankroll[0] < CAPITAL_GATE_GRID:
+        logger.warning(
+            f"Balance ${grid_bankroll[0]:.2f} < ${CAPITAL_GATE_GRID} capital gate — "
+            f"Grid suspended. No new positions opened."
+        )
+    else:
+        for market in tradeable:
+            if not is_grid_candidate(market):
+                continue
+            if is_already_gridded(grid_state, market.get("id", "")):
+                continue
+            grid_signal = open_grid(market, grid_bankroll[0])
+            if grid_signal is None:
+                continue
+            record_grid_trade(grid_state, grid_signal, grid_bankroll)
+            new_grid_trades.append(grid_signal.__dict__ if hasattr(grid_signal, '__dict__') else vars(grid_signal))
 
     state["virtual_bankroll"] = grid_bankroll[0]
 

--- a/polymarket_bot/run_paper_trade.py
+++ b/polymarket_bot/run_paper_trade.py
@@ -4,13 +4,18 @@ Daily paper trading runner — called by GitHub Actions.
 Flow:
   1. Fetch real Polymarket markets (Gamma API)
   2. Resolve any open S5/S2/S3 positions → update P&L
-  3. Run S3 Sniper v3 (Kelly-sized, crypto + sports verified) → record new signals
+  3. Run S3 Sniper v3.1 (Resolution Lag — crypto + sports verified) → record signals
   4. Send Telegram report
   5. Save updated state
 
-S5 (NicheSpecialist) and S2 (Grid) new entries are permanently suspended.
-All capital is allocated to S3 Sniper targeting MoM 20% returns.
-Existing open S5/S2 positions continue to resolve normally.
+S5 and S2 new entries are permanently suspended.
+All capital is allocated to S3 Sniper (Kelly-sized, externally verified).
+
+Monthly budget:
+  Each intraday scan counts toward MONTHLY_SCAN_LIMIT (default 1200).
+  When exhausted, scans skip until the month rolls over.
+  Daily reports and strategy reviews are never gated by the budget.
+  Intraday job runs the scanner TWICE per cron tick (effective ~2.5min cadence).
 """
 
 import logging
@@ -38,6 +43,12 @@ from telegram_reporter import send_daily_report, send_signal_alert
 
 # SEND_DAILY_REPORT=false → intraday scan mode (no full report, only signal alerts)
 SEND_DAILY_REPORT = os.environ.get("SEND_DAILY_REPORT", "true").lower() == "true"
+
+# Monthly scan budget — only applied to intraday scans, not daily reports.
+# GitHub Actions cron minimum is 5 min; intraday job runs 2 scans per tick
+# (effective interval ~2.5 min). Default 1200 ≈ ~2.5 days of max-rate scanning.
+# Adjust MONTHLY_SCAN_LIMIT repo variable to taste.
+MONTHLY_SCAN_LIMIT = int(os.environ.get("MONTHLY_SCAN_LIMIT", "1200"))
 
 # ── Legal exclusion: Taiwan politics / elections ──────────────────────────────
 # Blocked for legal compliance — do not trade on these markets.
@@ -74,12 +85,48 @@ def _is_blocked(market: dict) -> bool:
     return any(kw in text for kw in _TW_BLOCKED_KEYWORDS)
 
 
+def _check_scan_budget(state: dict) -> bool:
+    """
+    Increment and check the monthly intraday scan counter.
+    Returns False when the budget is exhausted for the current month.
+    Resets automatically on month rollover.
+    Only called for intraday scans (SEND_DAILY_REPORT=False).
+    """
+    this_month = datetime.now(timezone.utc).strftime("%Y-%m")
+
+    if state.get("scan_budget_month") != this_month:
+        state["scan_budget_month"] = this_month
+        state["scan_budget_count"] = 0
+
+    state["scan_budget_count"] = state.get("scan_budget_count", 0) + 1
+    used = state["scan_budget_count"]
+
+    if used > MONTHLY_SCAN_LIMIT:
+        logger.info(
+            f"Monthly scan budget exhausted ({used}/{MONTHLY_SCAN_LIMIT}) "
+            f"— skipping until {this_month} rolls over"
+        )
+        return False
+
+    if used % 50 == 0:
+        logger.info(f"Monthly scan budget: {used}/{MONTHLY_SCAN_LIMIT}")
+    return True
+
+
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 def main() -> None:
     mode = "daily report" if SEND_DAILY_REPORT else "intraday scan"
     logger.info(f"=== Paper trading run [{mode}] ===")
+
     state = load_state()
+
+    # Monthly budget gate — intraday scans only
+    if not SEND_DAILY_REPORT:
+        if not _check_scan_budget(state):
+            save_state(state)   # persist incremented counter
+            return
+
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
     # Step 1: Fetch markets
@@ -87,7 +134,7 @@ def main() -> None:
     raw_markets = fetch_active_markets(limit=800)
     markets_by_id = {m.get("id"): m for m in raw_markets if m.get("id")}
 
-    # Step 2: Resolve any open trades
+    # Step 2: Resolve any open trades (S5 / S2 legacy + S3 active)
     newly_resolved = check_resolutions(state, markets_by_id)
     if newly_resolved:
         logger.info(f"Resolved {len(newly_resolved)} trades today")
@@ -95,79 +142,59 @@ def main() -> None:
             result = "WIN" if t.outcome else "LOSS"
             logger.info(f"  [{result}] {t.question[:50]} | P&L: {t.pnl_usdc:+.2f}")
 
-    # Step 3: Apply legal filter
+    # Step 3: Legal filter
     blocked = [m for m in raw_markets if _is_blocked(m)]
     if blocked:
         logger.info(f"Blocked {len(blocked)} Taiwan politics/election markets")
     raw_markets_clean = [m for m in raw_markets if not _is_blocked(m)]
 
-    # S5 (NicheSpecialist) and S2 (Grid) new entries are suspended — all capital
-    # is allocated to S3 Sniper (Kelly-sized, externally verified, 97%+ WR).
-    # Resolution of existing open S5/S2 positions still runs below.
     new_trades: list = []
-    logger.info(
-        f"S5 suspended (MoM 20% target via S3 only) | "
-        f"Balance: ${state['virtual_bankroll']:.2f}"
-    )
 
-    # Step 4: S2 Grid strategy scan
+    # Step 4: S2 Grid — resolve existing positions only (no new entries)
     grid_state = load_grid_state()
     grid_bankroll = [state["virtual_bankroll"]]
-
     closed_grids = check_grid_updates(grid_state, markets_by_id, grid_bankroll)
     if closed_grids:
         logger.info(f"Grid: {len(closed_grids)} positions closed")
         for g in closed_grids:
             logger.info(f"  [GRID] {g['question'][:50]} | P&L: {g['pnl_usdc']:+.4f}")
-
-    # Grid new entries suspended — only resolving existing positions
     new_grid_trades: list = []
     state["virtual_bankroll"] = grid_bankroll[0]
 
-    logger.info(
-        f"Grid suspended (S2 new entries off) | "
-        f"Total P&L: ${grid_state['total_pnl']:+.4f}"
-    )
-
-    # Step 4b: S3 Near-Expiry Certainty Sniper
+    # Step 4b: S3 Sniper — resolve + scan
     sniper_state = load_sniper_state()
     sniper_bankroll = [state["virtual_bankroll"]]
 
-    # Resolve existing sniper positions
     closed_snipers = check_sniper_resolutions(sniper_state, markets_by_id, sniper_bankroll)
     if closed_snipers:
         logger.info(f"Sniper: {len(closed_snipers)} positions resolved")
 
-    # Fetch external price/result data for S3 Sniper verification
-    crypto_prices = fetch_crypto_prices()
+    crypto_prices  = fetch_crypto_prices()
+    sports_results = fetch_sports_results()
+
     if crypto_prices:
         logger.info(f"Crypto prices fetched: {list(crypto_prices.keys())}")
 
-    sports_results = fetch_sports_results()
-
-    # Scan all legal markets (not just tradeable) to catch more near-expiry candidates
     new_sniper_trades = []
-    sniper_candidates = find_sniper_candidates(
+    for signal in find_sniper_candidates(
         markets=raw_markets_clean,
         bankroll=sniper_bankroll[0],
         sniper_state=sniper_state,
         crypto_prices=crypto_prices,
         sports_results=sports_results,
-    )
-    for signal in sniper_candidates:
+    ):
         if sniper_bankroll[0] < signal.bet_usdc:
             continue
         record_sniper_trade(sniper_state, signal, sniper_bankroll)
         new_sniper_trades.append(signal.__dict__)
 
     state["virtual_bankroll"] = sniper_bankroll[0]
-
     logger.info(
-        f"Sniper: {len(new_sniper_trades)} new positions | "
-        f"Total P&L: ${sniper_state['total_pnl']:+.4f}"
+        f"Sniper: {len(new_sniper_trades)} new | balance=${state['virtual_bankroll']:.2f} | "
+        f"total_pnl={sniper_state['total_pnl']:+.4f}"
     )
 
-    # Step 5: Save state
+    # Step 5: Save all state
     state["last_run"] = today
     save_state(state)
     save_grid_state(grid_state)

--- a/polymarket_bot/strategy_grid.py
+++ b/polymarket_bot/strategy_grid.py
@@ -26,17 +26,20 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+
 logger = logging.getLogger(__name__)
 
 # ── Strategy parameters ────────────────────────────────────────────────────
-GRID_MID_MIN = 0.35       # only grid markets in this probability range
-GRID_MID_MAX = 0.65
+GRID_MID_MIN = 0.42       # tightened: true coin-flip only (was 0.35)
+GRID_MID_MAX = 0.58       # tightened: true coin-flip only (was 0.65)
 GRID_OFFSET = 0.015       # place orders 1.5% either side of mid
 GRID_MIN_SPREAD = 0.010   # skip if spread < 1.0% (not enough room)
-GRID_MAX_SPREAD = 0.200   # skip if spread > 20% (too illiquid, directional risk)
+GRID_MAX_SPREAD = 0.080   # tightened: skip illiquid (was 0.200)
 GRID_STOP_BAND = 0.20     # stop-loss if price moves ±20% from entry mid
 GRID_BET_FRACTION = 0.03  # 3% of bankroll per grid pair (buy + sell)
 GRID_MIN_BET = 0.10
+GRID_MIN_DAYS_TO_EXPIRY = 14  # skip markets resolving within 2 weeks (price converges, not oscillates)
+GRID_FEE_RATE = 0.018     # Polymarket taker fee as of March 2026 (was 0.02)
 
 STATE_FILE = Path("grid_trades.json")
 
@@ -73,12 +76,41 @@ def save_grid_state(state: dict) -> None:
     STATE_FILE.write_text(json.dumps(state, indent=2))
 
 
+def _days_to_expiry(market: dict) -> float | None:
+    """Return days until market end date, or None if unparseable."""
+    for key in ("endDate", "endDateIso", "end_date_iso"):
+        raw = market.get(key)
+        if not raw:
+            continue
+        try:
+            if isinstance(raw, (int, float)):
+                end_dt = datetime.fromtimestamp(float(raw), tz=timezone.utc)
+            else:
+                s = str(raw).strip().rstrip("Z")
+                if "T" in s:
+                    end_dt = datetime.fromisoformat(s)
+                    if end_dt.tzinfo is None:
+                        end_dt = end_dt.replace(tzinfo=timezone.utc)
+                else:
+                    end_dt = datetime.strptime(s[:10], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            return (end_dt - datetime.now(timezone.utc)).total_seconds() / 86400
+        except Exception:
+            continue
+    return None
+
+
 def is_grid_candidate(market: dict) -> bool:
-    """True if market is in coin-flip range with a decent but not extreme spread."""
+    """True if market is a genuine coin-flip with enough time left to oscillate."""
     mid = market.get("_mid_price", 0)
     spread = market.get("_best_ask", 0) - market.get("_best_bid", 0)
-    return (GRID_MID_MIN <= mid <= GRID_MID_MAX
-            and GRID_MIN_SPREAD <= spread <= GRID_MAX_SPREAD)
+    if not (GRID_MID_MIN <= mid <= GRID_MID_MAX
+            and GRID_MIN_SPREAD <= spread <= GRID_MAX_SPREAD):
+        return False
+    # Markets close to expiry will converge to 0/1, not oscillate — skip them
+    days = _days_to_expiry(market)
+    if days is not None and days < GRID_MIN_DAYS_TO_EXPIRY:
+        return False
+    return True
 
 
 def open_grid(market: dict, bankroll: float) -> Optional[GridTrade]:
@@ -125,7 +157,7 @@ def check_grid_updates(state: dict, markets_by_id: dict, bankroll_ref: list) -> 
     Returns list of closed trade dicts with pnl_usdc filled in.
     """
     closed_trades = []
-    fee_rate = 0.02
+    fee_rate = GRID_FEE_RATE
 
     for t in state["trades"]:
         if t.get("closed"):

--- a/polymarket_bot/strategy_sniper.py
+++ b/polymarket_bot/strategy_sniper.py
@@ -1,37 +1,23 @@
 """
-S3 Near-Expiry Certainty Sniper v2 — Polymarket paper trading.
+S3 Near-Expiry Certainty Sniper v3 — Polymarket paper trading.
 
-Research-backed rewrite.  Key changes from v1:
-  - Remove crowd-only entries (EV-negative: breakeven WR > ask × 1.018, unachievable)
-  - Fix fee model: loss = -bet (fee is charged at buy; NOT double-counted on losses)
-  - Fee rate updated to 1.80% (Polymarket rate as of March 2026; was 2.0%)
-  - Tighten MAX_ENTRY_PRICE to 0.95 (minimum 5% upside needed after 1.8% fee)
-  - Increase crypto price margin to 5% (was 3%) — prevents false positives on noisy ticks
-  - Add Coinbase as CoinGecko backup
-  - Add YES+NO combined-price arbitrage detection (guaranteed profit if YES+NO < $1)
+V3 changes (MoM 20% target):
+  - Kelly-based bet sizing (half-Kelly capped at 35% of bankroll)
+  - Confidence tiers: crypto margin 5%→0.97, 10%→0.99, 20%→0.995
+  - ESPN sports result verification (NBA, NFL, MLB, NHL, soccer)
+  - SNIPE_MIN_BET raised to $0.50, SNIPE_MAX_POSITIONS reduced to 3
+  - SNIPE_HOURS_AHEAD extended to 72h, SNIPE_OVERDUE_GRACE to 168h (7 days)
 
-Strategy (two profitable tiers)
----------------------------------
-Tier 1 — Crypto-verified (highest EV)
-  Market question references a crypto price threshold (BTC/ETH/SOL/etc).
-  We fetch live price from CoinGecko (+Coinbase fallback) and check if the
-  outcome is unambiguous (margin ≥ 5%).  When confirmed:
-    - Buy the winning side at current ask
-    - Expected WR ≈ 97%, EV ≈ +$0.12 per $2 trade at 90% ask.
-  Works for both OVERDUE and NEAR-EXPIRY windows.
+EV model (crypto, 97% WR, ask=0.88, $50 bankroll → 35% Kelly = $17.50):
+  win  = 17.50 × (1−0.88)/0.88 − 17.50×0.018 = 2.386 − 0.315 = +$2.07
+  loss = −17.50
+  EV   = 0.97×2.07 + 0.03×(−17.50) = 2.009 − 0.525 = +$1.48/trade
 
-Removed (EV analysis):
-  - near_expiry_crowd: crowd calibration at 88% bid → 86% actual WR.
-    Breakeven requires WR > 0.895 × 1.018 = 0.911. Unachievable.
-  - overdue_crowd: even at 94% WR, ask ≈ 0.94 → EV = 0.94×0.069 - 0.06×2 = -0.055.
-  - yes_no_arb: requires ask_YES < bid_YES (crossed book), impossible in live markets.
-    YES+NO combined cost = ask + (1-bid) = 1 + spread > 1. Adding fee makes it worse.
+5 crypto + 2 sports trades/month → ~$10–12 = 20%+ MoM on $50 ✓
 
-EV proof (corrected model):
-  crypto_verified, ask=0.90, WR=97%, bet=$2, fee=1.8%:
-    win  = 2 × (1-0.90)/0.90 - 2×0.018 = 0.222 - 0.036 = +0.186
-    loss = -2.00
-    EV   = 0.97×0.186 + 0.03×(-2) = 0.180 - 0.060 = +$0.120 ✓
+Fee model (unchanged):
+  WIN:  gross = bet × (1 – price) / price  minus  bet × fee
+  LOSS: pnl = –bet  ← fee paid at buy; do NOT double-count
 """
 
 from __future__ import annotations
@@ -41,20 +27,20 @@ import logging
 import re
 import urllib.request
 from dataclasses import dataclass, asdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 # ── Strategy parameters ────────────────────────────────────────────────────
-SNIPE_HOURS_AHEAD    = 48    # scan markets expiring within this window
-SNIPE_OVERDUE_GRACE  = 72   # ignore markets overdue by more than 3 days
-SNIPE_MAX_ENTRY      = 0.95  # never pay more than this (minimum 5% upside)
-SNIPE_BET_FRACTION   = 0.04  # 4% of bankroll per snipe
-SNIPE_MIN_BET        = 0.10
-SNIPE_MAX_POSITIONS  = 6     # cap concurrent sniper trades
-CRYPTO_MARGIN        = 0.05  # price must be 5% beyond threshold to confirm outcome
+SNIPE_HOURS_AHEAD    = 72     # scan markets expiring within 3 days
+SNIPE_OVERDUE_GRACE  = 168    # ignore markets overdue by more than 7 days
+SNIPE_MAX_ENTRY      = 0.95   # never pay more than 95¢ (min 5% upside after fee)
+SNIPE_HALF_KELLY_CAP = 0.35   # half-Kelly capped at 35% of bankroll
+SNIPE_MIN_BET        = 0.50   # minimum bet in USDC (raised from $0.10)
+SNIPE_MAX_POSITIONS  = 3      # maximum concurrent sniper positions (reduced from 6)
+CRYPTO_MARGIN        = 0.05   # price must be 5% beyond threshold to confirm
 
 # Polymarket taker fee as of March 2026
 POLYMARKET_FEE = 0.018
@@ -64,20 +50,31 @@ STATE_FILE = Path("sniper_trades.json")
 COINGECKO_API = "https://api.coingecko.com/api/v3/simple/price"
 COINBASE_API  = "https://api.coinbase.com/v2/prices/{}/spot"
 
+# Sport/league pairs for ESPN scoreboard API
+ESPN_SPORTS = [
+    ("basketball", "nba"),
+    ("football",   "nfl"),
+    ("baseball",   "mlb"),
+    ("hockey",     "nhl"),
+    ("soccer",     "eng.1"),
+    ("soccer",     "esp.1"),
+    ("soccer",     "uefa.champions"),
+]
+
 # Crypto symbol → (CoinGecko id, Coinbase pair, question regex)
 CRYPTO_MAP: dict[str, tuple[str, str, re.Pattern]] = {
-    "BTC":  ("bitcoin",       "BTC-USD",  re.compile(r'\b(?:btc|bitcoin)\b',         re.I)),
-    "ETH":  ("ethereum",      "ETH-USD",  re.compile(r'\b(?:eth|ethereum)\b',        re.I)),
-    "SOL":  ("solana",        "SOL-USD",  re.compile(r'\b(?:sol|solana)\b',          re.I)),
-    "DOGE": ("dogecoin",      "DOGE-USD", re.compile(r'\b(?:doge|dogecoin)\b',       re.I)),
-    "XRP":  ("ripple",        "XRP-USD",  re.compile(r'\b(?:xrp|ripple)\b',          re.I)),
-    "BNB":  ("binancecoin",   "BNB-USD",  re.compile(r'\b(?:bnb)\b',                 re.I)),
-    "MATIC":("matic-network", "MATIC-USD",re.compile(r'\b(?:matic|polygon)\b',       re.I)),
-    "ADA":  ("cardano",       "ADA-USD",  re.compile(r'\b(?:ada|cardano)\b',          re.I)),
-    "AVAX": ("avalanche-2",   "AVAX-USD", re.compile(r'\b(?:avax|avalanche)\b',      re.I)),
-    "LINK": ("chainlink",     "LINK-USD", re.compile(r'\b(?:link|chainlink)\b',      re.I)),
-    "DOT":  ("polkadot",      "DOT-USD",  re.compile(r'\b(?:dot|polkadot)\b',        re.I)),
-    "LTC":  ("litecoin",      "LTC-USD",  re.compile(r'\b(?:ltc|litecoin)\b',        re.I)),
+    "BTC":  ("bitcoin",       "BTC-USD",   re.compile(r'\b(?:btc|bitcoin)\b',        re.I)),
+    "ETH":  ("ethereum",      "ETH-USD",   re.compile(r'\b(?:eth|ethereum)\b',       re.I)),
+    "SOL":  ("solana",        "SOL-USD",   re.compile(r'\b(?:sol|solana)\b',         re.I)),
+    "DOGE": ("dogecoin",      "DOGE-USD",  re.compile(r'\b(?:doge|dogecoin)\b',      re.I)),
+    "XRP":  ("ripple",        "XRP-USD",   re.compile(r'\b(?:xrp|ripple)\b',         re.I)),
+    "BNB":  ("binancecoin",   "BNB-USD",   re.compile(r'\b(?:bnb)\b',                re.I)),
+    "MATIC":("matic-network", "MATIC-USD", re.compile(r'\b(?:matic|polygon)\b',      re.I)),
+    "ADA":  ("cardano",       "ADA-USD",   re.compile(r'\b(?:ada|cardano)\b',        re.I)),
+    "AVAX": ("avalanche-2",   "AVAX-USD",  re.compile(r'\b(?:avax|avalanche)\b',     re.I)),
+    "LINK": ("chainlink",     "LINK-USD",  re.compile(r'\b(?:link|chainlink)\b',     re.I)),
+    "DOT":  ("polkadot",      "DOT-USD",   re.compile(r'\b(?:dot|polkadot)\b',       re.I)),
+    "LTC":  ("litecoin",      "LTC-USD",   re.compile(r'\b(?:ltc|litecoin)\b',       re.I)),
 }
 
 _PRICE_RE = re.compile(r'\$\s*([\d,]+(?:\.\d+)?)\s*([kKmM]?)')
@@ -86,6 +83,9 @@ _ABOVE_RE = re.compile(
 )
 _BELOW_RE = re.compile(
     r'\b(?:below|under|falls?\s+(?:below|under)|drops?\s+(?:below|under)|at or below)\b', re.I
+)
+_WILL_WIN_RE = re.compile(
+    r'\bwill\s+(?:the\s+)?(.{2,40}?)\s+(?:win|beat|defeat|advance)', re.I
 )
 
 
@@ -100,10 +100,11 @@ class SniperTrade:
     price: float            # entry ask price per share
     bet_usdc: float
     shares: float
-    reason: str             # "overdue_crypto" | "near_expiry_crypto" | "yes_no_arb"
+    reason: str             # "overdue_crypto" | "near_expiry_crypto" | "sports_verified"
     hours_to_expiry: float  # negative = already overdue
-    live_price: Optional[float] = None   # verified external price
-    threshold: Optional[float] = None   # from market question
+    live_price: Optional[float] = None
+    threshold: Optional[float] = None
+    confidence: float = 0.0          # Kelly confidence (0.97 / 0.99 / 0.995)
     # Resolution tracking
     resolved: bool = False
     outcome: Optional[bool] = None
@@ -137,11 +138,39 @@ def record_sniper_trade(state: dict, trade: SniperTrade, bankroll_ref: list) -> 
     state["trades"].append(asdict(trade))
     logger.info(
         f"[SNIPER] {trade.question[:55]} | {trade.side} @ {trade.price:.3f} "
-        f"| {trade.reason} | h_left={trade.hours_to_expiry:.1f} | ${trade.bet_usdc:.2f}"
+        f"| {trade.reason} | conf={trade.confidence:.3f} | h_left={trade.hours_to_expiry:.1f} "
+        f"| ${trade.bet_usdc:.2f}"
     )
 
 
+# ── Kelly bet sizing ───────────────────────────────────────────────────────
+
+def _kelly_bet(confidence: float, ask: float, bankroll: float) -> float:
+    """Half-Kelly bet size, capped at SNIPE_HALF_KELLY_CAP of bankroll."""
+    if ask <= 0 or ask >= 1 or confidence <= 0:
+        return 0.0
+    b = (1.0 - ask) / ask        # net odds per unit wagered
+    p = confidence
+    q = 1.0 - p
+    f_full = (b * p - q) / b     # full Kelly fraction
+    if f_full <= 0:
+        return 0.0
+    fraction = min(f_full * 0.5, SNIPE_HALF_KELLY_CAP)
+    return round(max(bankroll * fraction, SNIPE_MIN_BET), 2)
+
+
 # ── Crypto price verification ──────────────────────────────────────────────
+
+def _crypto_confidence(margin: float) -> float:
+    """Map fractional price margin beyond threshold to confidence probability."""
+    if margin >= 0.20:
+        return 0.995
+    if margin >= 0.10:
+        return 0.990
+    if margin >= 0.05:
+        return 0.970
+    return 0.0
+
 
 def fetch_crypto_prices() -> dict:
     """
@@ -162,9 +191,9 @@ def fetch_crypto_prices() -> dict:
     # Per-symbol Coinbase fallback
     prices: dict = {}
     for sym, (cg_id, cb_pair, _) in CRYPTO_MAP.items():
-        url = COINBASE_API.format(cb_pair)
+        cb_url = COINBASE_API.format(cb_pair)
         try:
-            req = urllib.request.Request(url, headers={"User-Agent": "polymarket-bot/1.0"})
+            req = urllib.request.Request(cb_url, headers={"User-Agent": "polymarket-bot/1.0"})
             with urllib.request.urlopen(req, timeout=8) as resp:
                 d = json.loads(resp.read())
                 amount = float(d["data"]["amount"])
@@ -180,8 +209,7 @@ def fetch_crypto_prices() -> dict:
 def _parse_crypto_question(question: str) -> tuple[str, float, str] | None:
     """
     Extract (symbol, threshold, direction) from a crypto price question.
-    E.g. "Will BTC be above $100k by June?" → ("BTC", 100000.0, "above").
-    Returns None if not recognizable.
+    Returns None if question is not recognizable as a crypto price market.
     """
     for sym, (_, _, pattern) in CRYPTO_MAP.items():
         if pattern.search(question):
@@ -204,23 +232,140 @@ def _parse_crypto_question(question: str) -> tuple[str, float, str] | None:
     return None
 
 
-def _verify_crypto_outcome(live_price: float, threshold: float, direction: str) -> str | None:
+def _verify_crypto_outcome(
+    live_price: float, threshold: float, direction: str
+) -> tuple[str, float] | None:
     """
-    Returns "YES" or "NO" only when outcome is clear with CRYPTO_MARGIN buffer.
+    Returns (outcome, confidence) when price is unambiguously past threshold.
     Returns None when price is too close to the threshold to be certain.
-
-    5% margin prevents false positives from API tick noise.
     """
     if direction == "above":
         if live_price > threshold * (1 + CRYPTO_MARGIN):
-            return "YES"
+            margin = (live_price - threshold) / threshold
+            return "YES", _crypto_confidence(margin)
         if live_price < threshold * (1 - CRYPTO_MARGIN):
-            return "NO"
+            margin = (threshold - live_price) / threshold
+            return "NO", _crypto_confidence(margin)
     elif direction == "below":
         if live_price < threshold * (1 - CRYPTO_MARGIN):
-            return "YES"
+            margin = (threshold - live_price) / threshold
+            return "YES", _crypto_confidence(margin)
         if live_price > threshold * (1 + CRYPTO_MARGIN):
-            return "NO"
+            margin = (live_price - threshold) / threshold
+            return "NO", _crypto_confidence(margin)
+    return None
+
+
+# ── Sports result verification ─────────────────────────────────────────────
+
+def fetch_sports_results() -> list[dict]:
+    """
+    Fetch completed game results from ESPN public API for last 3 days.
+    Returns list of {league, winner, winner_short, winner_abbr,
+                      loser, loser_short, loser_abbr, completed, date}.
+    No API key required.
+    """
+    now = datetime.now(timezone.utc)
+    results: list[dict] = []
+
+    for sport, league in ESPN_SPORTS:
+        for days_ago in range(3):
+            date_str = (now - timedelta(days=days_ago)).strftime("%Y%m%d")
+            url = (
+                f"http://site.api.espn.com/apis/site/v2/sports"
+                f"/{sport}/{league}/scoreboard?dates={date_str}"
+            )
+            try:
+                req = urllib.request.Request(url, headers={"User-Agent": "polymarket-bot/1.0"})
+                with urllib.request.urlopen(req, timeout=8) as resp:
+                    data = json.loads(resp.read())
+            except Exception:
+                continue
+
+            for event in (data.get("events") or []):
+                status = ((event.get("status") or {}).get("type") or {})
+                if not status.get("completed"):
+                    continue
+                competitions = event.get("competitions") or []
+                if not competitions:
+                    continue
+                competitors = competitions[0].get("competitors") or []
+                if len(competitors) < 2:
+                    continue
+
+                winner_comp = next((c for c in competitors if c.get("winner")), None)
+                loser_comp  = next((c for c in competitors if not c.get("winner")), None)
+                if not winner_comp:
+                    continue
+
+                def _names(comp: dict) -> dict:
+                    team = comp.get("team") or {}
+                    return {
+                        "full":  team.get("displayName", ""),
+                        "short": team.get("shortDisplayName", "") or team.get("name", ""),
+                        "abbr":  team.get("abbreviation", ""),
+                    }
+
+                w = _names(winner_comp)
+                l = _names(loser_comp) if loser_comp else {"full": "", "short": "", "abbr": ""}
+
+                results.append({
+                    "league":        league,
+                    "winner":        w["full"],
+                    "winner_short":  w["short"],
+                    "winner_abbr":   w["abbr"],
+                    "loser":         l["full"],
+                    "loser_short":   l["short"],
+                    "loser_abbr":    l["abbr"],
+                    "completed":     True,
+                    "date":          date_str,
+                })
+
+    logger.info(f"ESPN: {len(results)} completed results fetched")
+    return results
+
+
+def _check_sports_question(
+    question: str, results: list[dict]
+) -> tuple[str, float] | None:
+    """
+    Match a Polymarket question to a completed ESPN game result.
+
+    Requires "Will [TEAM] win/beat/defeat..." pattern — conservative to avoid
+    false positives. Returns (side, 0.99) or None.
+    """
+    q = question.lower()
+
+    for r in results:
+        if not r.get("completed"):
+            continue
+
+        w_names = {
+            r.get("winner", "").lower(),
+            r.get("winner_short", "").lower(),
+            r.get("winner_abbr", "").lower(),
+        } - {""}
+        l_names = {
+            r.get("loser", "").lower(),
+            r.get("loser_short", "").lower(),
+            r.get("loser_abbr", "").lower(),
+        } - {""}
+
+        # Both teams must appear in question
+        if not (any(n in q for n in w_names) and any(n in q for n in l_names)):
+            continue
+
+        # "Will [X] win/beat/defeat/advance" — X is the YES subject
+        m = _WILL_WIN_RE.search(question)
+        if not m:
+            continue
+
+        subject = m.group(1).strip().lower()
+        if any(n in subject for n in w_names):
+            return "YES", 0.99
+        if any(n in subject for n in l_names):
+            return "NO", 0.99
+
     return None
 
 
@@ -245,7 +390,6 @@ def _parse_end_date(market: dict) -> datetime | None:
     return None
 
 
-
 # ── Core scan ─────────────────────────────────────────────────────────────
 
 def find_sniper_candidates(
@@ -253,19 +397,20 @@ def find_sniper_candidates(
     bankroll: float,
     sniper_state: dict,
     crypto_prices: dict | None = None,
+    sports_results: list[dict] | None = None,
 ) -> list[SniperTrade]:
     """
-    Scan markets for EV-positive sniper opportunities.
+    Scan markets for EV-positive sniper entries using external verification.
 
-    Only crypto-verified entries are considered (see module docstring for EV proof
-    of why crowd-only and YES+NO-arb entries were removed):
+    Accepted signal types (both use Kelly sizing):
+      - crypto_verified: crypto price beyond threshold with ≥5% margin
+      - sports_verified: completed ESPN game matches Polymarket question
 
-    markets       — list from Gamma API (after legal filter, pre quality-filter ok)
-    bankroll      — current virtual bankroll
-    sniper_state  — for dedup check (avoid re-entering open positions)
-    crypto_prices — CoinGecko / Coinbase prices dict
-
-    Returns list of SniperTrade signals (not yet recorded).
+    markets        — from Gamma API (after legal filter)
+    bankroll       — current virtual bankroll
+    sniper_state   — for dedup (avoid re-entering open positions)
+    crypto_prices  — CoinGecko/Coinbase prices dict
+    sports_results — ESPN completed game results from fetch_sports_results()
     """
     now = datetime.now(timezone.utc)
     signals: list[SniperTrade] = []
@@ -288,66 +433,74 @@ def find_sniper_candidates(
         if yes_bid <= 0 or yes_ask <= 0 or yes_bid >= yes_ask:
             continue
 
-        # Parse end date
         end_date = _parse_end_date(market)
         if end_date is None:
             continue
 
         hours_left = (end_date - now).total_seconds() / 3600
 
-        # ── Crypto-verified entries only (time window check) ─────────────
+        # Time window: not too stale, not too far out
         if hours_left < -SNIPE_OVERDUE_GRACE:
-            continue   # too stale
+            continue
         if hours_left > SNIPE_HOURS_AHEAD:
-            continue   # too far out
+            continue
 
         question = market.get("question", "")
-        parsed = _parse_crypto_question(question)
-        if not parsed or not crypto_prices:
-            continue  # no external verification possible → skip
-
-        sym, threshold, direction = parsed
-        cg_id = CRYPTO_MAP[sym][0]
-        live_price_raw = (crypto_prices.get(cg_id) or {}).get("usd")
-        if live_price_raw is None:
-            continue
-
-        live_price = float(live_price_raw)
-        outcome = _verify_crypto_outcome(live_price, threshold, direction)
-        if outcome is None:
-            continue   # too close to call
-
-        # Determine entry side and price
-        if outcome == "YES":
-            entry_price = yes_ask
-            side = "YES"
-        else:
-            entry_price = round(1.0 - yes_bid, 4)
-            side = "NO"
-
-        # Must have enough upside to profit after fee (strict >: at exactly MAX_ENTRY EV>0)
-        if entry_price > SNIPE_MAX_ENTRY:
-            continue
-
-        # EV sanity check: WR=97%, need win_pnl > loss_pnl × (1-WR)/WR
-        # Simplified: price < 0.95 already guarantees EV > 0 at 97% WR
         is_overdue = hours_left < 0
-        reason = "overdue_crypto" if is_overdue else "near_expiry_crypto"
 
-        bet = round(max(SNIPE_MIN_BET, bankroll * SNIPE_BET_FRACTION), 2)
-        signals.append(SniperTrade(
-            date=now.strftime("%Y-%m-%d"),
-            market_id=market_id,
-            question=question[:120],
-            side=side,
-            price=entry_price,
-            bet_usdc=bet,
-            shares=round(bet / entry_price, 4),
-            reason=reason,
-            hours_to_expiry=round(hours_left, 1),
-            live_price=round(live_price, 2),
-            threshold=threshold,
-        ))
+        # ── Try crypto verification ────────────────────────────────────────
+        parsed = _parse_crypto_question(question)
+        if parsed and crypto_prices:
+            sym, threshold, direction = parsed
+            cg_id = CRYPTO_MAP[sym][0]
+            live_price_raw = (crypto_prices.get(cg_id) or {}).get("usd")
+            if live_price_raw is not None:
+                live_price = float(live_price_raw)
+                result = _verify_crypto_outcome(live_price, threshold, direction)
+                if result is not None:
+                    outcome, confidence = result
+                    entry_price = yes_ask if outcome == "YES" else round(1.0 - yes_bid, 4)
+                    if entry_price <= SNIPE_MAX_ENTRY:
+                        bet = _kelly_bet(confidence, entry_price, bankroll)
+                        if bet > 0 and bankroll >= bet:
+                            reason = "overdue_crypto" if is_overdue else "near_expiry_crypto"
+                            signals.append(SniperTrade(
+                                date=now.strftime("%Y-%m-%d"),
+                                market_id=market_id,
+                                question=question[:120],
+                                side=outcome,
+                                price=entry_price,
+                                bet_usdc=bet,
+                                shares=round(bet / entry_price, 4),
+                                reason=reason,
+                                hours_to_expiry=round(hours_left, 1),
+                                live_price=round(live_price, 2),
+                                threshold=threshold,
+                                confidence=confidence,
+                            ))
+                            continue  # don't double-check sports for same market
+
+        # ── Try sports verification ────────────────────────────────────────
+        if sports_results:
+            sport_result = _check_sports_question(question, sports_results)
+            if sport_result is not None:
+                outcome, confidence = sport_result
+                entry_price = yes_ask if outcome == "YES" else round(1.0 - yes_bid, 4)
+                if entry_price <= SNIPE_MAX_ENTRY:
+                    bet = _kelly_bet(confidence, entry_price, bankroll)
+                    if bet > 0 and bankroll >= bet:
+                        signals.append(SniperTrade(
+                            date=now.strftime("%Y-%m-%d"),
+                            market_id=market_id,
+                            question=question[:120],
+                            side=outcome,
+                            price=entry_price,
+                            bet_usdc=bet,
+                            shares=round(bet / entry_price, 4),
+                            reason="sports_verified",
+                            hours_to_expiry=round(hours_left, 1),
+                            confidence=confidence,
+                        ))
 
     return signals
 
@@ -363,9 +516,9 @@ def check_sniper_resolutions(
     Check open sniper trades against resolved markets.
     Returns list of closed trade dicts (with pnl_usdc filled in).
 
-    Fee model (corrected):
+    Fee model:
       WIN:  gross = bet × (1 – price) / price  minus  bet × fee
-      LOSS: pnl = –bet   ← fee was already paid at buy time, do NOT double-count
+      LOSS: pnl = –bet   ← fee was already paid at buy time; no double-count
     """
     closed: list[dict] = []
 
@@ -404,7 +557,7 @@ def check_sniper_resolutions(
             gross = bet * (1.0 - price) / price
             pnl = round(gross - bet * POLYMARKET_FEE, 4)
         else:
-            pnl = round(-bet, 4)   # fee already paid at buy; no double-count
+            pnl = round(-bet, 4)
 
         t["resolved"]  = True
         t["outcome"]   = won
@@ -415,7 +568,7 @@ def check_sniper_resolutions(
         result = "WIN" if won else "LOSS"
         logger.info(
             f"[SNIPER] {result}: {t.get('question', '?')[:50]} | "
-            f"{side} @ {price:.3f} | P&L={pnl:+.4f}"
+            f"{side} @ {price:.3f} | conf={t.get('confidence', 0):.3f} | P&L={pnl:+.4f}"
         )
         closed.append(t)
 

--- a/polymarket_bot/strategy_sniper.py
+++ b/polymarket_bot/strategy_sniper.py
@@ -1,23 +1,36 @@
 """
-S3 Near-Expiry Certainty Sniper v3 — Polymarket paper trading.
+S3 Near-Expiry Certainty Sniper v3.1 — Resolution Lag Architecture
 
-V3 changes (MoM 20% target):
-  - Kelly-based bet sizing (half-Kelly capped at 35% of bankroll)
-  - Confidence tiers: crypto margin 5%→0.97, 10%→0.99, 20%→0.995
-  - ESPN sports result verification (NBA, NFL, MLB, NHL, soccer)
-  - SNIPE_MIN_BET raised to $0.50, SNIPE_MAX_POSITIONS reduced to 3
-  - SNIPE_HOURS_AHEAD extended to 72h, SNIPE_OVERDUE_GRACE to 168h (7 days)
+The only reliable edge is betting on outcomes ALREADY determined in the real
+world but not yet resolved on Polymarket (resolution lag window).
 
-EV model (crypto, 97% WR, ask=0.88, $50 bankroll → 35% Kelly = $17.50):
-  win  = 17.50 × (1−0.88)/0.88 − 17.50×0.018 = 2.386 − 0.315 = +$2.07
-  loss = −17.50
-  EV   = 0.97×2.07 + 0.03×(−17.50) = 2.009 − 0.525 = +$1.48/trade
+Two verified signal types:
 
-5 crypto + 2 sports trades/month → ~$10–12 = 20%+ MoM on $50 ✓
+  Tier 1 — Overdue + Crypto (highest priority)
+    Market endDate has passed, BTC/ETH/etc. price is unambiguously past the
+    threshold (≥5% margin).  Resolution is certain; Polymarket just hasn't
+    closed the market yet.  Kelly cap: 35%.
 
-Fee model (unchanged):
-  WIN:  gross = bet × (1 – price) / price  minus  bet × fee
-  LOSS: pnl = –bet  ← fee paid at buy; do NOT double-count
+  Tier 2 — Near-Expiry Crypto (< 6h to endDate)
+    Market expires within 6 hours, current crypto price ≈ final price.
+    Small time discount applied to confidence.  Kelly cap: 20%.
+
+  Tier 3 — Sports Verified (any open market)
+    ESPN confirms the game is completed and we match the winner to the
+    Polymarket question.  No time restriction — game completion IS the
+    signal regardless of where endDate sits.  Kelly cap: 35%.
+
+What we removed vs crowd-only / speculative entries:
+  ✗ 72h forward-looking crypto: BTC can move a lot in 3 days, not a "known" outcome
+  ✗ Overdue crowd (high bid): calibration shows crowd is systematically wrong here
+  ✗ YES/NO arb: spread + fee makes it EV-negative
+
+EV proof (overdue crypto, 97% WR, ask=0.88, $100 bankroll → 35% Kelly = $35):
+  win  = 35 × (1−0.88)/0.88 − 35×0.018 = 4.773 − 0.630 = +$4.143
+  loss = −35
+  EV   = 0.97×4.143 + 0.03×(−35) = 4.019 − 1.050 = +$2.97/trade
+
+5 trades/month → $14.85 = 14.9% MoM; add sports tier → 20%+ ✓
 """
 
 from __future__ import annotations
@@ -34,23 +47,34 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 # ── Strategy parameters ────────────────────────────────────────────────────
-SNIPE_HOURS_AHEAD    = 72     # scan markets expiring within 3 days
-SNIPE_OVERDUE_GRACE  = 168    # ignore markets overdue by more than 7 days
-SNIPE_MAX_ENTRY      = 0.95   # never pay more than 95¢ (min 5% upside after fee)
-SNIPE_HALF_KELLY_CAP = 0.35   # half-Kelly capped at 35% of bankroll
-SNIPE_MIN_BET        = 0.50   # minimum bet in USDC (raised from $0.10)
-SNIPE_MAX_POSITIONS  = 3      # maximum concurrent sniper positions (reduced from 6)
-CRYPTO_MARGIN        = 0.05   # price must be 5% beyond threshold to confirm
 
-# Polymarket taker fee as of March 2026
-POLYMARKET_FEE = 0.018
+# Crypto: only enter if within this many hours of endDate OR already overdue
+# Beyond 6h, the crypto price can change enough to flip the outcome → skip
+SNIPE_CRYPTO_MAX_HOURS = 6
+
+# How many hours past endDate we still consider an overdue market valid
+SNIPE_OVERDUE_GRACE = 168     # 7 days
+
+# Maximum entry price (must leave at least 5% upside after 1.8% fee)
+SNIPE_MAX_ENTRY = 0.95
+
+# Kelly fraction caps by confidence tier
+SNIPE_KELLY_CAP_OVERDUE = 0.35   # overdue market: outcome already determined
+SNIPE_KELLY_CAP_NEAR    = 0.20   # near-expiry (<6h): small time-price risk remains
+
+# Minimum bet and maximum concurrent positions
+SNIPE_MIN_BET       = 1.00   # $1 minimum (bankroll is now $100)
+SNIPE_MAX_POSITIONS = 5
+
+# Price must be this far beyond the threshold to call the outcome
+CRYPTO_MARGIN = 0.05          # 5% margin → confidence 0.97
+POLYMARKET_FEE = 0.018        # Polymarket taker fee, March 2026
 
 STATE_FILE = Path("sniper_trades.json")
 
 COINGECKO_API = "https://api.coingecko.com/api/v3/simple/price"
 COINBASE_API  = "https://api.coinbase.com/v2/prices/{}/spot"
 
-# Sport/league pairs for ESPN scoreboard API
 ESPN_SPORTS = [
     ("basketball", "nba"),
     ("football",   "nfl"),
@@ -61,20 +85,19 @@ ESPN_SPORTS = [
     ("soccer",     "uefa.champions"),
 ]
 
-# Crypto symbol → (CoinGecko id, Coinbase pair, question regex)
 CRYPTO_MAP: dict[str, tuple[str, str, re.Pattern]] = {
-    "BTC":  ("bitcoin",       "BTC-USD",   re.compile(r'\b(?:btc|bitcoin)\b',        re.I)),
-    "ETH":  ("ethereum",      "ETH-USD",   re.compile(r'\b(?:eth|ethereum)\b',       re.I)),
-    "SOL":  ("solana",        "SOL-USD",   re.compile(r'\b(?:sol|solana)\b',         re.I)),
-    "DOGE": ("dogecoin",      "DOGE-USD",  re.compile(r'\b(?:doge|dogecoin)\b',      re.I)),
-    "XRP":  ("ripple",        "XRP-USD",   re.compile(r'\b(?:xrp|ripple)\b',         re.I)),
-    "BNB":  ("binancecoin",   "BNB-USD",   re.compile(r'\b(?:bnb)\b',                re.I)),
-    "MATIC":("matic-network", "MATIC-USD", re.compile(r'\b(?:matic|polygon)\b',      re.I)),
-    "ADA":  ("cardano",       "ADA-USD",   re.compile(r'\b(?:ada|cardano)\b',        re.I)),
-    "AVAX": ("avalanche-2",   "AVAX-USD",  re.compile(r'\b(?:avax|avalanche)\b',     re.I)),
-    "LINK": ("chainlink",     "LINK-USD",  re.compile(r'\b(?:link|chainlink)\b',     re.I)),
-    "DOT":  ("polkadot",      "DOT-USD",   re.compile(r'\b(?:dot|polkadot)\b',       re.I)),
-    "LTC":  ("litecoin",      "LTC-USD",   re.compile(r'\b(?:ltc|litecoin)\b',       re.I)),
+    "BTC":   ("bitcoin",       "BTC-USD",   re.compile(r'\b(?:btc|bitcoin)\b',        re.I)),
+    "ETH":   ("ethereum",      "ETH-USD",   re.compile(r'\b(?:eth|ethereum)\b',       re.I)),
+    "SOL":   ("solana",        "SOL-USD",   re.compile(r'\b(?:sol|solana)\b',         re.I)),
+    "DOGE":  ("dogecoin",      "DOGE-USD",  re.compile(r'\b(?:doge|dogecoin)\b',      re.I)),
+    "XRP":   ("ripple",        "XRP-USD",   re.compile(r'\b(?:xrp|ripple)\b',         re.I)),
+    "BNB":   ("binancecoin",   "BNB-USD",   re.compile(r'\b(?:bnb)\b',                re.I)),
+    "MATIC": ("matic-network", "MATIC-USD", re.compile(r'\b(?:matic|polygon)\b',      re.I)),
+    "ADA":   ("cardano",       "ADA-USD",   re.compile(r'\b(?:ada|cardano)\b',        re.I)),
+    "AVAX":  ("avalanche-2",   "AVAX-USD",  re.compile(r'\b(?:avax|avalanche)\b',     re.I)),
+    "LINK":  ("chainlink",     "LINK-USD",  re.compile(r'\b(?:link|chainlink)\b',     re.I)),
+    "DOT":   ("polkadot",      "DOT-USD",   re.compile(r'\b(?:dot|polkadot)\b',       re.I)),
+    "LTC":   ("litecoin",      "LTC-USD",   re.compile(r'\b(?:ltc|litecoin)\b',       re.I)),
 }
 
 _PRICE_RE = re.compile(r'\$\s*([\d,]+(?:\.\d+)?)\s*([kKmM]?)')
@@ -96,16 +119,15 @@ class SniperTrade:
     date: str
     market_id: str
     question: str
-    side: str               # "YES" or "NO"
-    price: float            # entry ask price per share
+    side: str                   # "YES" or "NO"
+    price: float                # entry ask price per share
     bet_usdc: float
     shares: float
-    reason: str             # "overdue_crypto" | "near_expiry_crypto" | "sports_verified"
-    hours_to_expiry: float  # negative = already overdue
+    reason: str                 # "overdue_crypto" | "near_expiry_crypto" | "sports_verified"
+    hours_to_expiry: float      # negative = already overdue
     live_price: Optional[float] = None
     threshold: Optional[float] = None
-    confidence: float = 0.0          # Kelly confidence (0.97 / 0.99 / 0.995)
-    # Resolution tracking
+    confidence: float = 0.0    # probability used in Kelly calculation
     resolved: bool = False
     outcome: Optional[bool] = None
     pnl_usdc: Optional[float] = None
@@ -138,31 +160,30 @@ def record_sniper_trade(state: dict, trade: SniperTrade, bankroll_ref: list) -> 
     state["trades"].append(asdict(trade))
     logger.info(
         f"[SNIPER] {trade.question[:55]} | {trade.side} @ {trade.price:.3f} "
-        f"| {trade.reason} | conf={trade.confidence:.3f} | h_left={trade.hours_to_expiry:.1f} "
-        f"| ${trade.bet_usdc:.2f}"
+        f"| {trade.reason} | conf={trade.confidence:.3f} "
+        f"| h_left={trade.hours_to_expiry:.1f} | ${trade.bet_usdc:.2f}"
     )
 
 
 # ── Kelly bet sizing ───────────────────────────────────────────────────────
 
-def _kelly_bet(confidence: float, ask: float, bankroll: float) -> float:
-    """Half-Kelly bet size, capped at SNIPE_HALF_KELLY_CAP of bankroll."""
+def _kelly_bet(confidence: float, ask: float, bankroll: float, kelly_cap: float) -> float:
+    """Half-Kelly bet size capped at kelly_cap fraction of bankroll."""
     if ask <= 0 or ask >= 1 or confidence <= 0:
         return 0.0
-    b = (1.0 - ask) / ask        # net odds per unit wagered
+    b = (1.0 - ask) / ask
     p = confidence
-    q = 1.0 - p
-    f_full = (b * p - q) / b     # full Kelly fraction
+    f_full = (b * p - (1.0 - p)) / b
     if f_full <= 0:
         return 0.0
-    fraction = min(f_full * 0.5, SNIPE_HALF_KELLY_CAP)
+    fraction = min(f_full * 0.5, kelly_cap)
     return round(max(bankroll * fraction, SNIPE_MIN_BET), 2)
 
 
-# ── Crypto price verification ──────────────────────────────────────────────
+# ── Crypto price fetching & verification ──────────────────────────────────
 
 def _crypto_confidence(margin: float) -> float:
-    """Map fractional price margin beyond threshold to confidence probability."""
+    """Map fractional price margin beyond threshold to base confidence."""
     if margin >= 0.20:
         return 0.995
     if margin >= 0.10:
@@ -188,7 +209,6 @@ def fetch_crypto_prices() -> dict:
     except Exception as exc:
         logger.warning(f"CoinGecko fetch failed: {exc}")
 
-    # Per-symbol Coinbase fallback
     prices: dict = {}
     for sym, (cg_id, cb_pair, _) in CRYPTO_MAP.items():
         cb_url = COINBASE_API.format(cb_pair)
@@ -196,21 +216,16 @@ def fetch_crypto_prices() -> dict:
             req = urllib.request.Request(cb_url, headers={"User-Agent": "polymarket-bot/1.0"})
             with urllib.request.urlopen(req, timeout=8) as resp:
                 d = json.loads(resp.read())
-                amount = float(d["data"]["amount"])
-                prices[cg_id] = {"usd": amount}
+                prices[cg_id] = {"usd": float(d["data"]["amount"])}
         except Exception:
             pass
-
     if prices:
         logger.info(f"Coinbase fallback: fetched {len(prices)} prices")
     return prices
 
 
 def _parse_crypto_question(question: str) -> tuple[str, float, str] | None:
-    """
-    Extract (symbol, threshold, direction) from a crypto price question.
-    Returns None if question is not recognizable as a crypto price market.
-    """
+    """Extract (symbol, threshold, direction) from a crypto price question, or None."""
     for sym, (_, _, pattern) in CRYPTO_MAP.items():
         if pattern.search(question):
             m = _PRICE_RE.search(question)
@@ -222,13 +237,12 @@ def _parse_crypto_question(question: str) -> tuple[str, float, str] | None:
                 num *= 1_000
             elif mult == "M":
                 num *= 1_000_000
-
             q = question.lower()
             if _ABOVE_RE.search(q):
                 return sym, num, "above"
             if _BELOW_RE.search(q):
                 return sym, num, "below"
-            return None  # direction ambiguous
+            return None
     return None
 
 
@@ -236,34 +250,29 @@ def _verify_crypto_outcome(
     live_price: float, threshold: float, direction: str
 ) -> tuple[str, float] | None:
     """
-    Returns (outcome, confidence) when price is unambiguously past threshold.
-    Returns None when price is too close to the threshold to be certain.
+    Return (outcome, base_confidence) when price is unambiguously past threshold.
+    None when too close to call.
     """
     if direction == "above":
         if live_price > threshold * (1 + CRYPTO_MARGIN):
-            margin = (live_price - threshold) / threshold
-            return "YES", _crypto_confidence(margin)
+            return "YES", _crypto_confidence((live_price - threshold) / threshold)
         if live_price < threshold * (1 - CRYPTO_MARGIN):
-            margin = (threshold - live_price) / threshold
-            return "NO", _crypto_confidence(margin)
+            return "NO", _crypto_confidence((threshold - live_price) / threshold)
     elif direction == "below":
         if live_price < threshold * (1 - CRYPTO_MARGIN):
-            margin = (threshold - live_price) / threshold
-            return "YES", _crypto_confidence(margin)
+            return "YES", _crypto_confidence((threshold - live_price) / threshold)
         if live_price > threshold * (1 + CRYPTO_MARGIN):
-            margin = (live_price - threshold) / threshold
-            return "NO", _crypto_confidence(margin)
+            return "NO", _crypto_confidence((live_price - threshold) / threshold)
     return None
 
 
-# ── Sports result verification ─────────────────────────────────────────────
+# ── Sports result fetching & verification ─────────────────────────────────
 
 def fetch_sports_results() -> list[dict]:
     """
-    Fetch completed game results from ESPN public API for last 3 days.
-    Returns list of {league, winner, winner_short, winner_abbr,
-                      loser, loser_short, loser_abbr, completed, date}.
+    Fetch completed game results from ESPN public scoreboard API for last 3 days.
     No API key required.
+    Returns list of normalised result dicts.
     """
     now = datetime.now(timezone.utc)
     results: list[dict] = []
@@ -299,26 +308,24 @@ def fetch_sports_results() -> list[dict]:
                     continue
 
                 def _names(comp: dict) -> dict:
-                    team = comp.get("team") or {}
+                    t = comp.get("team") or {}
                     return {
-                        "full":  team.get("displayName", ""),
-                        "short": team.get("shortDisplayName", "") or team.get("name", ""),
-                        "abbr":  team.get("abbreviation", ""),
+                        "full":  t.get("displayName", ""),
+                        "short": t.get("shortDisplayName", "") or t.get("name", ""),
+                        "abbr":  t.get("abbreviation", ""),
                     }
 
                 w = _names(winner_comp)
                 l = _names(loser_comp) if loser_comp else {"full": "", "short": "", "abbr": ""}
-
                 results.append({
-                    "league":        league,
-                    "winner":        w["full"],
-                    "winner_short":  w["short"],
-                    "winner_abbr":   w["abbr"],
-                    "loser":         l["full"],
-                    "loser_short":   l["short"],
-                    "loser_abbr":    l["abbr"],
-                    "completed":     True,
-                    "date":          date_str,
+                    "league":       league,
+                    "winner":       w["full"],
+                    "winner_short": w["short"],
+                    "winner_abbr":  w["abbr"],
+                    "loser":        l["full"],
+                    "loser_short":  l["short"],
+                    "loser_abbr":   l["abbr"],
+                    "completed":    True,
                 })
 
     logger.info(f"ESPN: {len(results)} completed results fetched")
@@ -329,37 +336,25 @@ def _check_sports_question(
     question: str, results: list[dict]
 ) -> tuple[str, float] | None:
     """
-    Match a Polymarket question to a completed ESPN game result.
-
-    Requires "Will [TEAM] win/beat/defeat..." pattern — conservative to avoid
-    false positives. Returns (side, 0.99) or None.
+    Match a Polymarket question to a completed ESPN game.
+    Uses conservative "Will [TEAM] win/beat/defeat/advance" pattern.
+    Returns (side, 0.99) or None.
     """
     q = question.lower()
-
     for r in results:
         if not r.get("completed"):
             continue
+        w_names = {r.get("winner","").lower(), r.get("winner_short","").lower(),
+                   r.get("winner_abbr","").lower()} - {""}
+        l_names = {r.get("loser","").lower(),  r.get("loser_short","").lower(),
+                   r.get("loser_abbr","").lower()}  - {""}
 
-        w_names = {
-            r.get("winner", "").lower(),
-            r.get("winner_short", "").lower(),
-            r.get("winner_abbr", "").lower(),
-        } - {""}
-        l_names = {
-            r.get("loser", "").lower(),
-            r.get("loser_short", "").lower(),
-            r.get("loser_abbr", "").lower(),
-        } - {""}
-
-        # Both teams must appear in question
         if not (any(n in q for n in w_names) and any(n in q for n in l_names)):
             continue
 
-        # "Will [X] win/beat/defeat/advance" — X is the YES subject
         m = _WILL_WIN_RE.search(question)
         if not m:
             continue
-
         subject = m.group(1).strip().lower()
         if any(n in subject for n in w_names):
             return "YES", 0.99
@@ -372,7 +367,6 @@ def _check_sports_question(
 # ── Date parsing ───────────────────────────────────────────────────────────
 
 def _parse_end_date(market: dict) -> datetime | None:
-    """Extract end date as UTC-aware datetime."""
     for key in ("endDate", "endDateIso", "end_date_iso", "endDateISO"):
         raw = market.get(key)
         if not raw:
@@ -400,17 +394,16 @@ def find_sniper_candidates(
     sports_results: list[dict] | None = None,
 ) -> list[SniperTrade]:
     """
-    Scan markets for EV-positive sniper entries using external verification.
+    Resolution-Lag-first scanner.  Priority:
+      1. Overdue crypto (endDate passed, price unambiguous)
+      2. Near-expiry crypto (< 6h, current price ≈ resolution price)
+      3. Sports verified (game completed per ESPN, market still open)
 
-    Accepted signal types (both use Kelly sizing):
-      - crypto_verified: crypto price beyond threshold with ≥5% margin
-      - sports_verified: completed ESPN game matches Polymarket question
-
-    markets        — from Gamma API (after legal filter)
-    bankroll       — current virtual bankroll
-    sniper_state   — for dedup (avoid re-entering open positions)
-    crypto_prices  — CoinGecko/Coinbase prices dict
-    sports_results — ESPN completed game results from fetch_sports_results()
+    markets       — Gamma API markets (after legal filter)
+    bankroll      — current virtual bankroll
+    sniper_state  — for dedup
+    crypto_prices — from fetch_crypto_prices()
+    sports_results — from fetch_sports_results()
     """
     now = datetime.now(timezone.utc)
     signals: list[SniperTrade] = []
@@ -439,55 +432,63 @@ def find_sniper_candidates(
 
         hours_left = (end_date - now).total_seconds() / 3600
 
-        # Time window: not too stale, not too far out
+        # Drop markets too stale to trade
         if hours_left < -SNIPE_OVERDUE_GRACE:
-            continue
-        if hours_left > SNIPE_HOURS_AHEAD:
             continue
 
         question = market.get("question", "")
         is_overdue = hours_left < 0
+        entered = False
 
-        # ── Try crypto verification ────────────────────────────────────────
-        parsed = _parse_crypto_question(question)
-        if parsed and crypto_prices:
-            sym, threshold, direction = parsed
-            cg_id = CRYPTO_MAP[sym][0]
-            live_price_raw = (crypto_prices.get(cg_id) or {}).get("usd")
-            if live_price_raw is not None:
-                live_price = float(live_price_raw)
-                result = _verify_crypto_outcome(live_price, threshold, direction)
-                if result is not None:
-                    outcome, confidence = result
-                    entry_price = yes_ask if outcome == "YES" else round(1.0 - yes_bid, 4)
-                    if entry_price <= SNIPE_MAX_ENTRY:
-                        bet = _kelly_bet(confidence, entry_price, bankroll)
-                        if bet > 0 and bankroll >= bet:
-                            reason = "overdue_crypto" if is_overdue else "near_expiry_crypto"
-                            signals.append(SniperTrade(
-                                date=now.strftime("%Y-%m-%d"),
-                                market_id=market_id,
-                                question=question[:120],
-                                side=outcome,
-                                price=entry_price,
-                                bet_usdc=bet,
-                                shares=round(bet / entry_price, 4),
-                                reason=reason,
-                                hours_to_expiry=round(hours_left, 1),
-                                live_price=round(live_price, 2),
-                                threshold=threshold,
-                                confidence=confidence,
-                            ))
-                            continue  # don't double-check sports for same market
+        # ── Tier 1 & 2: Crypto verification ───────────────────────────────
+        # Only enter if within SNIPE_CRYPTO_MAX_HOURS of endDate OR already overdue.
+        # Markets >6h away can still have significant price movement before expiry.
+        if crypto_prices and (is_overdue or hours_left <= SNIPE_CRYPTO_MAX_HOURS):
+            parsed = _parse_crypto_question(question)
+            if parsed:
+                sym, threshold, direction = parsed
+                cg_id = CRYPTO_MAP[sym][0]
+                raw_price = (crypto_prices.get(cg_id) or {}).get("usd")
+                if raw_price is not None:
+                    live_price = float(raw_price)
+                    verified = _verify_crypto_outcome(live_price, threshold, direction)
+                    if verified is not None:
+                        outcome, base_conf = verified
+                        if base_conf > 0:
+                            # Slightly discount confidence for near-expiry (price still has time to move)
+                            confidence = base_conf if is_overdue else base_conf * 0.90
+                            kelly_cap  = SNIPE_KELLY_CAP_OVERDUE if is_overdue else SNIPE_KELLY_CAP_NEAR
+                            entry_price = yes_ask if outcome == "YES" else round(1.0 - yes_bid, 4)
+                            if entry_price <= SNIPE_MAX_ENTRY:
+                                bet = _kelly_bet(confidence, entry_price, bankroll, kelly_cap)
+                                if bet > 0 and bankroll >= bet:
+                                    reason = "overdue_crypto" if is_overdue else "near_expiry_crypto"
+                                    signals.append(SniperTrade(
+                                        date=now.strftime("%Y-%m-%d"),
+                                        market_id=market_id,
+                                        question=question[:120],
+                                        side=outcome,
+                                        price=entry_price,
+                                        bet_usdc=bet,
+                                        shares=round(bet / entry_price, 4),
+                                        reason=reason,
+                                        hours_to_expiry=round(hours_left, 1),
+                                        live_price=round(live_price, 2),
+                                        threshold=threshold,
+                                        confidence=confidence,
+                                    ))
+                                    entered = True
 
-        # ── Try sports verification ────────────────────────────────────────
-        if sports_results:
+        # ── Tier 3: Sports verification ────────────────────────────────────
+        # No time restriction: game completion is the signal, not endDate proximity.
+        # Game can complete before endDate (e.g., game June 19, endDate June 21).
+        if not entered and sports_results:
             sport_result = _check_sports_question(question, sports_results)
             if sport_result is not None:
                 outcome, confidence = sport_result
                 entry_price = yes_ask if outcome == "YES" else round(1.0 - yes_bid, 4)
                 if entry_price <= SNIPE_MAX_ENTRY:
-                    bet = _kelly_bet(confidence, entry_price, bankroll)
+                    bet = _kelly_bet(confidence, entry_price, bankroll, SNIPE_KELLY_CAP_OVERDUE)
                     if bet > 0 and bankroll >= bet:
                         signals.append(SniperTrade(
                             date=now.strftime("%Y-%m-%d"),
@@ -518,14 +519,13 @@ def check_sniper_resolutions(
 
     Fee model:
       WIN:  gross = bet × (1 – price) / price  minus  bet × fee
-      LOSS: pnl = –bet   ← fee was already paid at buy time; no double-count
+      LOSS: pnl = –bet   ← fee paid at buy; no double-count
     """
     closed: list[dict] = []
 
     for t in state["trades"]:
         if t.get("resolved"):
             continue
-
         market = markets_by_id.get(t["market_id"])
         if not market or not market.get("closed"):
             continue
@@ -546,18 +546,14 @@ def check_sniper_resolutions(
         yes_won = prices[0] >= 0.99
         no_won  = prices[1] >= 0.99
         if not (yes_won or no_won):
-            continue  # not fully resolved yet
+            continue
 
-        side = t["side"]
-        won  = (side == "YES" and yes_won) or (side == "NO" and no_won)
-        bet  = t["bet_usdc"]
+        side  = t["side"]
+        won   = (side == "YES" and yes_won) or (side == "NO" and no_won)
+        bet   = t["bet_usdc"]
         price = t["price"]
 
-        if won:
-            gross = bet * (1.0 - price) / price
-            pnl = round(gross - bet * POLYMARKET_FEE, 4)
-        else:
-            pnl = round(-bet, 4)
+        pnl = round(bet * (1.0 - price) / price - bet * POLYMARKET_FEE, 4) if won else round(-bet, 4)
 
         t["resolved"]  = True
         t["outcome"]   = won
@@ -565,10 +561,9 @@ def check_sniper_resolutions(
         state["total_pnl"] = round(state["total_pnl"] + pnl, 4)
         bankroll_ref[0]    = round(bankroll_ref[0] + pnl, 4)
 
-        result = "WIN" if won else "LOSS"
         logger.info(
-            f"[SNIPER] {result}: {t.get('question', '?')[:50]} | "
-            f"{side} @ {price:.3f} | conf={t.get('confidence', 0):.3f} | P&L={pnl:+.4f}"
+            f"[SNIPER] {'WIN' if won else 'LOSS'}: {t.get('question','?')[:50]} | "
+            f"{side} @ {price:.3f} | conf={t.get('confidence',0):.3f} | P&L={pnl:+.4f}"
         )
         closed.append(t)
 


### PR DESCRIPTION
## Summary

Complete redesign of the paper trading bot targeting **MoM 20% returns** with a fresh $100 bankroll.

### Core insight: Resolution Lag is the only reliable edge

Polymarket takes 12–48h to close markets after real-world events complete. During this window, prices may still be at 0.85–0.93 for an outcome that is already certain. All three strategies (S3/S2/S5) previously entered based on *prediction* — now S3 v3.1 only enters based on *already-known outcomes*.

### Strategy changes (`strategy_sniper.py` → v3.1)

- **Crypto signals**: only enter within **6h of endDate OR already overdue** — beyond 6h, price can still flip
- **Sports signals**: no time restriction — ESPN `completed=True` is the signal; game completion creates the lag window
- **Near-expiry crypto** (0–6h): 10% confidence discount + 20% Kelly cap
- **Overdue crypto**: full margin-based confidence (0.97/0.99/0.995) + 35% Kelly cap
- `SNIPE_MIN_BET` raised to $1.00, `SNIPE_MAX_POSITIONS` raised to 5
- Kelly bet function now takes explicit `kelly_cap` per tier

### Run loop (`run_paper_trade.py`)

- Monthly scan budget: `MONTHLY_SCAN_LIMIT` (default 1200, configurable via repo variable)
- Counter resets automatically on month rollover; daily report / strategy review never gated
- S5 / S2 new entries permanently suspended; existing positions still resolve

### Scan frequency (`.github/workflows/polymarket_bot.yml`)

- Intraday job now runs the scanner **twice per tick** with 120s sleep → effective cadence **~2.5 min**
- `timeout-minutes` raised 8 → 12
- `MONTHLY_SCAN_LIMIT` wired from `vars.MONTHLY_SCAN_LIMIT` (fallback 1200)

### Reset (`paper_trader.py` + cache key bump)

- `STARTING_BANKROLL = 100.0` (was 50.0)
- Cache key bumped to `paper-state-v2-*` → forces fresh empty state on next run

## EV model

```
Overdue crypto, 97% WR, ask=0.88, $100 bankroll → 35% Kelly = $35:
  win  = 35 × 0.12/0.88 − 35×0.018 = +$4.14
  loss = −$35
  EV   = 0.97×4.14 + 0.03×(−35) = +$2.97/trade
5 crypto + 2 sports trades/month → ~$20 = 20% MoM ✓
```

## Test plan

- [ ] Confirm next Actions run starts with `virtual_bankroll: 100.0`
- [ ] Verify intraday job runs two scans per tick in Actions logs
- [ ] Confirm `scan_budget_count` increments and resets on month rollover
- [ ] Watch for first S3 signal: overdue crypto or sports-verified market
- [ ] After 2 weeks, review signal frequency to validate Resolution Lag hypothesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein

---
_Generated by [Claude Code](https://claude.ai/code/session_01GspT1CuEvXXnFKb6ucGein)_